### PR TITLE
Active tab not saving on refresh

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -103,10 +103,10 @@ export function App(props: AppProps): JSX.Element {
     if (tabsToLoad.length > 0) {
       store.dispatch("editor.openTab", {
         note: tabsToLoad,
-        active: first(sidebar.selected),
+        active: editor.activeTabNoteId ?? first(sidebar.selected),
       });
     }
-  }, [editor.tabs, store, sidebar.selected]);
+  }, [editor.tabs, editor.activeTabNoteId, store, sidebar.selected]);
 
   return (
     <Container>
@@ -178,10 +178,9 @@ async function loadInitialState(): Promise<State> {
   };
 }
 
-/*
- * Don't move these to be in Sidebar.tsx. Otherwise the listener will only work
- * when the sidebar is being rendered.
- */
+// N.B. app.toggleSidebar listener must be keep here because if we move it to
+// Sidebar.tsx the listener won't work when the sidebar is hidden because the
+// component isn't being rendered.
 export const toggleSidebar: Listener<"app.toggleSidebar"> = (_, ctx) => {
   ctx.setUI((prev) => ({
     sidebar: {

--- a/src/renderer/components/EditorTabs.tsx
+++ b/src/renderer/components/EditorTabs.tsx
@@ -435,7 +435,7 @@ export const openTab: Listener<"editor.openTab"> = async (ev, ctx) => {
   });
 
   // When the selected note is opened we need to change focus to the editor
-  // because it means the user wants to start editting the note.
+  // because it means the user wants to start editing the note.
   if (ev.value == null) {
     ctx.focus([Section.Editor], { overwrite: true });
   }

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -23,7 +23,7 @@ import {
   faChevronRight,
 } from "@fortawesome/free-solid-svg-icons";
 import { SidebarSearch } from "./SidebarSearch";
-import { search } from "fast-fuzzy";
+import { search as searchFuzzy } from "fast-fuzzy";
 import { filterOutStaleNoteIds } from "../../shared/ui/app";
 import { SidebarNewNoteButton } from "./SidebarNewNoteButton";
 import { Section } from "../../shared/ui/app";
@@ -121,7 +121,7 @@ export function Sidebar(props: SidebarProps): JSX.Element {
     store.on(["sidebar.deleteNote", "sidebar.deleteSelectedNote"], deleteNote);
     store.on("sidebar.dragNote", dragNote);
     store.on("sidebar.moveNoteToTrash", moveNoteToTrash);
-    store.on("sidebar.setSearchString", setSearchString);
+    store.on("sidebar.search", search);
     store.on("sidebar.collapseAll", collapseAll);
     store.on("sidebar.expandAll", expandAll);
     store.on("sidebar.setNoteSort", setNoteSort);
@@ -149,7 +149,7 @@ export function Sidebar(props: SidebarProps): JSX.Element {
       );
       store.off("sidebar.dragNote", dragNote);
       store.off("sidebar.moveNoteToTrash", moveNoteToTrash);
-      store.off("sidebar.setSearchString", setSearchString);
+      store.off("sidebar.search", search);
       store.off("sidebar.collapseAll", collapseAll);
       store.off("sidebar.expandAll", expandAll);
       store.off("sidebar.setNoteSort", setNoteSort);
@@ -211,7 +211,7 @@ export function applySearchString(
   }
 
   const flatNotes = flatten(notes);
-  const matches = search(searchString!, flatNotes, {
+  const matches = searchFuzzy(searchString!, flatNotes, {
     keySelector: (n) => n.name,
   });
 
@@ -673,7 +673,7 @@ export const dragNote: Listener<"sidebar.dragNote"> = async (
   }
 };
 
-export const setSearchString: Listener<"sidebar.setSearchString"> = async (
+export const search: Listener<"sidebar.search"> = async (
   { value: searchString },
   ctx
 ) => {

--- a/src/renderer/components/SidebarSearch.tsx
+++ b/src/renderer/components/SidebarSearch.tsx
@@ -20,16 +20,13 @@ export function SidebarSearch(props: SidebarSearchProps): JSX.Element {
 
   const onInput = useCallback(
     (ev: React.FormEvent) => {
-      store.dispatch(
-        "sidebar.setSearchString",
-        (ev.target as HTMLInputElement).value
-      );
+      store.dispatch("sidebar.search", (ev.target as HTMLInputElement).value);
     },
     [store]
   );
 
   const onClear = useCallback(() => {
-    store.dispatch("sidebar.setSearchString", "");
+    store.dispatch("sidebar.search", "");
   }, [store]);
 
   const { searchString = "" } = state.sidebar;

--- a/src/shared/ui/events.ts
+++ b/src/shared/ui/events.ts
@@ -42,7 +42,7 @@ export interface UIEvents {
   "sidebar.toggleItemExpanded": string;
   "sidebar.moveSelectionUp": void;
   "sidebar.moveSelectionDown": void;
-  "sidebar.setSearchString": string;
+  "sidebar.search": string;
   "sidebar.focusSearch": void;
 
   // Editor
@@ -109,7 +109,7 @@ export const LIST_OF_EVENTS: (keyof UIEvents)[] = [
   "sidebar.toggleItemExpanded",
   "sidebar.moveSelectionUp",
   "sidebar.moveSelectionDown",
-  "sidebar.setSearchString",
+  "sidebar.search",
   "sidebar.focusSearch",
 
   // Editor


### PR DESCRIPTION
Fix for a small bug that was causing the editor to change active tabs when the app is reloaded.