### PR TITLE
Allow using dev tools outside dev

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,7 @@ module.exports = {
   moduleNameMapper: {
     "monaco-editor": "<rootDir>/test/__mocks__/monaco.ts",
   },
+  clearMocks: true,
   globals: {
     "ts-jest": {
       // ts-jest configuration goes here

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -18,12 +18,9 @@ export const DEFAULT_WINDOW_WIDTH = 800;
 export function configIpcs(
   ipc: IpcMainTS,
   config: JsonFile<Config>,
-  log: Logger
+  log: Logger,
 ): void {
-  ipc.handle(
-    "config.hasDataDirectory",
-    async () => config.content.dataDirectory != null
-  );
+  ipc.handle("config.get", () => config.content);
 
   ipc.handle("config.openDataDirectory", async () => {
     if (config.content.dataDirectory == null) {
@@ -62,7 +59,7 @@ export async function getConfig(): Promise<JsonFile<Config>> {
         windowWidth: DEFAULT_WINDOW_WIDTH,
         logDirectory: app.getPath("logs"),
       },
-    }
+    },
   );
 
   // Override directories when running in development.

--- a/src/main/schemas/config/2_addLogDirectory.ts
+++ b/src/main/schemas/config/2_addLogDirectory.ts
@@ -11,7 +11,7 @@ export interface ConfigV2 {
 }
 
 export const configSchemaV2: z.Schema<ConfigV2> = z.preprocess(
-  (obj) => {
+  obj => {
     const config = obj as ConfigV1 | ConfigV2;
 
     if (config.version === 1) {
@@ -30,5 +30,5 @@ export const configSchemaV2: z.Schema<ConfigV2> = z.preprocess(
     windowWidth: z.number().min(1),
     dataDirectory: z.string().optional(),
     logDirectory: z.string(),
-  })
+  }),
 );

--- a/src/main/schemas/config/3_addDeveloperMode.ts
+++ b/src/main/schemas/config/3_addDeveloperMode.ts
@@ -7,7 +7,7 @@ export interface ConfigV3 {
   windowWidth: number;
   dataDirectory?: string;
   logDirectory?: string;
-  showDevTools?: boolean;
+  developerMode?: boolean;
 }
 
 export const configSchemaV3: z.Schema<ConfigV3> = z.preprocess(
@@ -25,6 +25,6 @@ export const configSchemaV3: z.Schema<ConfigV3> = z.preprocess(
     windowWidth: z.number().min(1),
     dataDirectory: z.string().optional(),
     logDirectory: z.string(),
-    showDevTools: z.boolean().optional(),
+    developerMode: z.boolean().optional(),
   }),
 );

--- a/src/main/schemas/config/3_addShowDevTools.ts
+++ b/src/main/schemas/config/3_addShowDevTools.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+import { ConfigV2 } from "./2_addLogDirectory";
+
+export interface ConfigV3 {
+  version: number;
+  windowHeight: number;
+  windowWidth: number;
+  dataDirectory?: string;
+  logDirectory?: string;
+  showDevTools?: boolean;
+}
+
+export const configSchemaV3: z.Schema<ConfigV3> = z.preprocess(
+  obj => {
+    const config = obj as ConfigV2 | ConfigV3;
+    if (config.version === 2) {
+      config.version = 3;
+    }
+
+    return config;
+  },
+  z.object({
+    version: z.literal(3),
+    windowHeight: z.number().min(1),
+    windowWidth: z.number().min(1),
+    dataDirectory: z.string().optional(),
+    logDirectory: z.string(),
+    showDevTools: z.boolean().optional(),
+  }),
+);

--- a/src/main/schemas/config/index.ts
+++ b/src/main/schemas/config/index.ts
@@ -1,7 +1,9 @@
 import { configSchemaV1 } from "./1_initialDefinition";
 import { configSchemaV2 } from "./2_addLogDirectory";
+import { configSchemaV3 } from "./3_addShowDevTools";
 
 export const CONFIG_SCHEMAS = {
   1: configSchemaV1,
   2: configSchemaV2,
+  3: configSchemaV3,
 };

--- a/src/main/schemas/config/index.ts
+++ b/src/main/schemas/config/index.ts
@@ -1,6 +1,6 @@
 import { configSchemaV1 } from "./1_initialDefinition";
 import { configSchemaV2 } from "./2_addLogDirectory";
-import { configSchemaV3 } from "./3_addShowDevTools";
+import { configSchemaV3 } from "./3_addDeveloperMode";
 
 export const CONFIG_SCHEMAS = {
   1: configSchemaV1,

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -51,13 +51,14 @@ export interface AppProps {
 }
 
 export function App(props: AppProps): JSX.Element {
+  const { config } = props;
   const store = useStore(props.state);
   const { state } = store;
   const { sidebar, editor } = state;
 
   useShortcuts(store);
-  useApplicationMenu(store);
-  useContextMenu(store);
+  useApplicationMenu(store, config);
+  useContextMenu(store, config);
   useEffect(() => {
     store.on("app.quit", quit);
     store.on("app.toggleSidebar", toggleSidebar);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -17,15 +17,15 @@ import { useContextMenu } from "./menus/contextMenu";
 import { Editor } from "./components/Editor";
 import { h100, HEADER_SIZES, mb2, w100 } from "./css";
 import { AppState } from "../shared/ui/app";
-import { log } from "./logger";
+import { Config } from "../shared/domain/config";
 
 const { ipc } = window;
 async function main() {
+  let config: Config;
   let initialState: State;
-  let needDataDirectory = false;
 
   try {
-    needDataDirectory = !(await ipc("config.hasDataDirectory"));
+    config = await ipc("config.get");
     initialState = await loadInitialState();
   } catch (e) {
     console.error("Fatal Error", e);
@@ -35,7 +35,7 @@ async function main() {
   }
 
   render(
-    <App initialState={initialState} needDataDirectory={needDataDirectory} />,
+    <App state={initialState} config={config} />,
     document.getElementById("app"),
   );
 }
@@ -46,12 +46,12 @@ if (!isTest()) {
 }
 
 export interface AppProps {
-  initialState: State;
-  needDataDirectory: boolean;
+  state: State;
+  config: Config;
 }
 
 export function App(props: AppProps): JSX.Element {
-  const store = useStore(props.initialState);
+  const store = useStore(props.state);
   const { state } = store;
   const { sidebar, editor } = state;
 
@@ -112,7 +112,9 @@ export function App(props: AppProps): JSX.Element {
     <Container>
       {!(state.sidebar.hidden ?? false) && <Sidebar store={store} />}
       <Editor store={store} />
-      {props.needDataDirectory && <DataDirectoryModal store={store} />}
+      {props.config.dataDirectory == null && (
+        <DataDirectoryModal store={store} />
+      )}
     </Container>
   );
 }

--- a/src/renderer/io/shortcuts.ts
+++ b/src/renderer/io/shortcuts.ts
@@ -38,10 +38,10 @@ export function useShortcuts(store: Store): void {
 
   if (didKeysChange) {
     const shortcut = shortcuts.find(
-      (s) =>
+      s =>
         !s.disabled &&
         isEqual(s.keys, toKeyArray(activeKeys.current)) &&
-        shouldExecute(state.focused, s.when)
+        shouldExecute(state.focused, s.when),
     );
 
     if (shortcut != null) {
@@ -116,7 +116,7 @@ export function shouldExecute(focused?: Section[], when?: Section): boolean {
 }
 
 export const toKeyArray = (
-  activeKeys: Record<string, boolean | undefined>
+  activeKeys: Record<string, boolean | undefined>,
 ): KeyCode[] =>
   chain(activeKeys)
     .entries()
@@ -126,7 +126,7 @@ export const toKeyArray = (
     .value();
 
 export function getShortcutLabels(
-  shortcuts: Shortcut[]
+  shortcuts: Shortcut[],
 ): Partial<Record<UIEventType, string>> {
   const lookup: Partial<Record<UIEventType, string>> = {};
 

--- a/src/renderer/menus/appMenu.ts
+++ b/src/renderer/menus/appMenu.ts
@@ -4,14 +4,15 @@ import { isDevelopment } from "../../shared/env";
 import { getShortcutLabels } from "../io/shortcuts";
 import { Store } from "../store";
 import { IpcChannel } from "../../shared/ipc";
+import { Config } from "../../shared/domain/config";
 
-export function useApplicationMenu(store: Store): void {
+export function useApplicationMenu(store: Store, config: Config): void {
   const { state } = store;
 
-  // useMemo prevents unnecessary renders
+  // useMemo prevents unnecessary re-renders
   const shortcutLabels = useMemo(
     () => getShortcutLabels(store.state.shortcuts),
-    [store.state.shortcuts]
+    [store.state.shortcuts],
   );
   const focused = state.focused[0];
   const selected = state.sidebar.selected?.[0];
@@ -19,7 +20,7 @@ export function useApplicationMenu(store: Store): void {
 
   useEffect(() => {
     const optionals: Menu[] = [];
-    if (isDevelopment()) {
+    if (isDevelopment() || config.developerMode) {
       optionals.push({
         label: "&Developer",
         type: "submenu",
@@ -140,7 +141,7 @@ export function useApplicationMenu(store: Store): void {
       },
       ...optionals,
     ]);
-  }, [focused, selected, shortcutLabels, isEditing]);
+  }, [focused, selected, shortcutLabels, isEditing, config]);
 
   useEffect(() => {
     const onClick = (ev: CustomEvent) => {

--- a/src/renderer/menus/contextMenu.ts
+++ b/src/renderer/menus/contextMenu.ts
@@ -15,14 +15,15 @@ import { Store } from "../store";
 import { Section } from "../../shared/ui/app";
 import { getEditorTabAttribute } from "../components/EditorTabs";
 import { IpcChannel } from "../../shared/ipc";
+import { Config } from "../../shared/domain/config";
 
-export function useContextMenu(store: Store): void {
+export function useContextMenu(store: Store, config: Config): void {
   const { state } = store;
 
   // useMemo prevents unnecessary renders
   const shortcutLabels = useMemo(
     () => getShortcutLabels(state.shortcuts),
-    [state.shortcuts]
+    [state.shortcuts],
   );
 
   useEffect(() => {
@@ -69,7 +70,7 @@ export function useContextMenu(store: Store): void {
                 event: "sidebar.moveNoteToTrash",
                 eventInput: noteId,
                 shortcut: shortcutLabels["sidebar.moveNoteToTrash"],
-              }
+              },
             );
           }
 
@@ -142,7 +143,7 @@ export function useContextMenu(store: Store): void {
         }
       }
 
-      if (isDevelopment()) {
+      if (isDevelopment() || config.developerMode) {
         const { x, y } = (ev.target as HTMLElement).getBoundingClientRect();
 
         items.push({
@@ -170,7 +171,7 @@ export function useContextMenu(store: Store): void {
     return () => {
       window.removeEventListener("contextmenu", showMenu);
     };
-  }, [shortcutLabels, store, state.notes, state.sidebar.sort]);
+  }, [shortcutLabels, store, state.notes, state.sidebar.sort, config]);
 
   useEffect(() => {
     const onClick = (ev: CustomEvent) => {
@@ -189,7 +190,7 @@ export function buildNoteSortMenu(globalSort: NoteSort, note?: Note): SubMenu {
   const label = note ? "Sort children by" : "Sort notes by";
   const currentSort = note?.sort ?? globalSort;
 
-  const children: Menu[] = Object.values(NoteSort).map((sort) => ({
+  const children: Menu[] = Object.values(NoteSort).map(sort => ({
     label: NOTE_SORT_LABELS[sort],
     type: "radio",
     checked: currentSort === sort,

--- a/src/shared/domain/config.ts
+++ b/src/shared/domain/config.ts
@@ -4,5 +4,5 @@ export interface Config {
   windowWidth: number;
   dataDirectory?: string;
   logDirectory: string;
-  showDevTools?: boolean;
+  developerMode?: boolean;
 }

--- a/src/shared/domain/config.ts
+++ b/src/shared/domain/config.ts
@@ -4,4 +4,5 @@ export interface Config {
   windowWidth: number;
   dataDirectory?: string;
   logDirectory: string;
+  showDevTools?: boolean;
 }

--- a/src/shared/io/defaultShortcuts.ts
+++ b/src/shared/io/defaultShortcuts.ts
@@ -18,6 +18,7 @@ const shortcuts: Shortcut[] = [
     name: "app.openDevTools",
     event: "app.openDevTools",
     keys: [KeyCode.Control, KeyCode.Shift, KeyCode.LetterI],
+    // We leave shortcut enabled even when developer mode isn't enabled for now.
   },
   {
     name: "app.reload",
@@ -146,7 +147,7 @@ const shortcuts: Shortcut[] = [
   },
 ];
 
-export const DEFAULT_SHORTCUTS = shortcuts.map((s) => ({
+export const DEFAULT_SHORTCUTS = shortcuts.map(s => ({
   ...s,
   // Ensure keys are always in correct order
   keys: sortKeyCodes(s.keys),

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -29,7 +29,7 @@ export const IPCS = [
   "notes.delete",
   "notes.moveToTrash",
 
-  "config.hasDataDirectory",
+  "config.get",
   "config.selectDataDirectory",
   "config.openDataDirectory",
 
@@ -97,7 +97,7 @@ export interface IpcMainTS extends Pick<IpcMain, "listeners"> {
     handler: (
       event: IpcMainInvokeEvent,
       ...params: Parameters<IpcSchema[Type]>
-    ) => ReturnType<IpcSchema[Type]>
+    ) => ReturnType<IpcSchema[Type]>,
   ): void;
   on(event: IpcEvent, callback: () => Promise<void>): void;
 }

--- a/test/__factories__/config.ts
+++ b/test/__factories__/config.ts
@@ -8,5 +8,6 @@ export function createConfig(partial?: DeepPartial<Config>): Config {
     windowHeight: partial?.windowHeight ?? 600,
     windowWidth: partial?.windowWidth ?? 800,
     dataDirectory: partial?.dataDirectory ?? "/data",
+    developerMode: partial?.developerMode,
   };
 }

--- a/test/renderer/components/Focusable.spec.tsx
+++ b/test/renderer/components/Focusable.spec.tsx
@@ -11,10 +11,11 @@ import React, { ReactNode } from "react";
 import * as store from "../../../src/renderer/store";
 import { mockStore } from "../../__mocks__/store";
 import { Section } from "../../../src/shared/ui/app";
+import { createConfig } from "../../__factories__/config";
 
 function init(
   props: FocusableProps,
-  content: ReactNode = undefined
+  content: ReactNode = undefined,
 ): RenderResult {
   jest.spyOn(store, "useStore").mockImplementation(() => props.store);
   return render(<Focusable {...props}>{content}</Focusable>);
@@ -24,7 +25,9 @@ test("useFocusTracking detects clicks in focusables", async () => {
   const s = mockStore();
   jest.spyOn(store, "useStore").mockImplementation(() => s);
 
-  const res = render(<App initialState={s.state} needDataDirectory={false} />);
+  const res = render(
+    <App state={s.state} config={createConfig({ dataDirectory: "foo" })} />,
+  );
 
   // Simulate a click within the sidebar search.
   const searchbar = await res.findByPlaceholderText("Type to search...");
@@ -43,7 +46,7 @@ test("focusable sets attribute", () => {
 
 test.each([undefined, false, true])(
   "focusable focuses (focusOnRender %s)",
-  (focusOnRender) => {
+  focusOnRender => {
     const store = mockStore({
       state: { focused: [Section.Sidebar] },
     });
@@ -59,7 +62,7 @@ test.each([undefined, false, true])(
         elementRef: el,
         onFocus,
       },
-      "Hello World!"
+      "Hello World!",
     );
 
     if (focusOnRender === undefined || focusOnRender === true) {
@@ -69,12 +72,12 @@ test.each([undefined, false, true])(
     }
 
     expect(onFocus).toBeCalled();
-  }
+  },
 );
 
 test.each([false, true])(
   "focusable blurs (focusOnRender %s)",
-  (focusOnRender) => {
+  focusOnRender => {
     const store = mockStore({ state: { focused: [Section.Editor] } });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const el = { current: { blur: jest.fn() } } as React.MutableRefObject<any>;
@@ -95,7 +98,7 @@ test.each([false, true])(
     }
 
     expect(onBlur).toBeCalled();
-  }
+  },
 );
 
 test("focusable only blurs when current has changed", async () => {
@@ -112,14 +115,14 @@ test("focusable only blurs when current has changed", async () => {
   res.rerender(
     <Focusable name={Section.Sidebar} store={store} onBlur={onBlur}>
       Hello World!
-    </Focusable>
+    </Focusable>,
   );
   expect(onBlur).not.toBeCalled();
 });
 
 test.each([false, true])(
   "focusable blurs on escape (blurOnEsc: %s)",
-  async (blurOnEsc) => {
+  async blurOnEsc => {
     const store = mockStore();
     const res = init(
       {
@@ -127,7 +130,7 @@ test.each([false, true])(
         store,
         blurOnEsc,
       },
-      <input title="random-title"></input>
+      <input title="random-title"></input>,
     );
 
     const input = res.getByTitle("random-title");
@@ -138,7 +141,7 @@ test.each([false, true])(
     } else {
       expect(store.dispatch).not.toBeCalled();
     }
-  }
+  },
 );
 
 test("wasInsideFocusable true", () => {

--- a/test/renderer/menus/appMenu.spec.ts
+++ b/test/renderer/menus/appMenu.spec.ts
@@ -1,0 +1,36 @@
+import { createConfig } from "../../__factories__/config";
+import { createStore } from "../../__factories__/store";
+import { useApplicationMenu } from "../../../src/renderer/menus/appMenu";
+import { renderHook } from "@testing-library/react-hooks";
+import * as env from "../../../src/shared/env";
+import { Menu, SubMenu } from "../../../src/shared/ui/menu";
+
+// Keep in sync with useContextMenu
+test.each([
+  [false, false, false],
+  [true, false, true],
+  [false, true, true],
+  [true, true, true],
+])(
+  "useApplicationMenu (isDevelopment: %s, developerMode: %s, shouldSeeDevMenu: %s)",
+  async (isDevelopment, developerMode, shouldSeeDevMenu) => {
+    jest.spyOn(env, "isDevelopment").mockReturnValue(isDevelopment);
+
+    const store = createStore();
+    const config = createConfig({ developerMode });
+
+    renderHook(() => {
+      useApplicationMenu(store.current, config);
+    });
+
+    // Second argument of first call.
+    const options: Menu[] = ((window as any).ipc as jest.Mock).mock.calls[0][1];
+    const devMenu = options.find(m => (m as SubMenu).label === "&Developer");
+
+    if (shouldSeeDevMenu) {
+      expect(devMenu).not.toBe(undefined);
+    } else {
+      expect(devMenu).toBe(undefined);
+    }
+  },
+);


### PR DESCRIPTION
This PR adds a new config property `developerMode` that will allow users to access dev tools.

It's a small but subtle feature that'll make debugging the application a little easier. Can be enabled by setting `developerMode: true` within your `config.json`.