### PR TITLE
Search note content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2435,6 +2435,15 @@
       "dev": true,
       "optional": true
     },
+    "@types/mock-fs": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@types/mock-fs/-/mock-fs-4.13.1.tgz",
+      "integrity": "sha512-m6nFAJ3lBSnqbvDZioawRvpLXSaPyn52Srf7OfzjubYbYX8MTUdIgDxQl0wEapm4m/pNYSd9TXocpQ0TvZFlYA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
       "version": "17.0.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
@@ -9701,6 +9710,12 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "mock-fs": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.2.0.tgz",
+      "integrity": "sha512-2dF2R6YMSZbpip1V1WHKGLNjr/k48uQClqMVb5H3MOvwc9qhYis3/IWbj02qIg/Y8MDXKFF4c5v0rxx2o6xTZw==",
+      "dev": true
     },
     "monaco-editor": {
       "version": "0.33.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "make": "electron-forge make",
     "publish": "./scripts/build",
     "lint": "eslint --ext .ts,.tsx .",
-    "test": "jest ./test --config=jest.config.js"
+    "test": "jest"
   },
   "keywords": [],
   "author": {
@@ -33,6 +33,7 @@
     "@types/jest": "^27.0.2",
     "@types/jest-when": "^3.5.0",
     "@types/lodash": "^4.14.176",
+    "@types/mock-fs": "^4.13.1",
     "@types/react": "^17.0.33",
     "@types/react-dom": "^17.0.10",
     "@types/react-test-renderer": "^17.0.1",
@@ -52,6 +53,7 @@
     "html-webpack-plugin": "^4.5.2",
     "jest": "^27.3.1",
     "jest-when": "^3.5.1",
+    "mock-fs": "^5.2.0",
     "node-loader": "^2.0.0",
     "style-loader": "^3.0.0",
     "ts-jest": "^27.0.7",

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -24,7 +24,7 @@ export const APP_STATE_PATH = "ui.json";
 export function appIpcs(
   ipc: IpcMainTS,
   config: JsonFile<Config>,
-  log: Logger
+  log: Logger,
 ): void {
   let appStateFile: JsonFile<AppState>;
 
@@ -52,7 +52,7 @@ export function appIpcs(
           },
           focused: [],
         },
-      }
+      },
     );
   });
 
@@ -67,7 +67,7 @@ export function appIpcs(
   ipc.handle("app.showContextMenu", async (_, menus) => {
     const template: MenuItemConstructorOptions[] = buildMenus(
       menus,
-      IpcChannel.ContextMenuClick
+      IpcChannel.ContextMenuClick,
     );
     const menu = Menu.buildFromTemplate(template);
     menu.popup();
@@ -77,7 +77,7 @@ export function appIpcs(
   ipc.handle("app.setApplicationMenu", async (_, menus) => {
     const template: MenuItemConstructorOptions[] = buildMenus(
       menus,
-      IpcChannel.ApplicationMenuClick
+      IpcChannel.ApplicationMenuClick,
     );
     const bw = BrowserWindow.getFocusedWindow();
     const menu = Menu.buildFromTemplate(template);
@@ -85,10 +85,8 @@ export function appIpcs(
   });
 
   ipc.handle("app.promptUser", async (_, opts) => {
-    const cancelCount = opts.buttons.filter((b) => b.role === "cancel").length;
-    const defaultCount = opts.buttons.filter(
-      (b) => b.role === "default"
-    ).length;
+    const cancelCount = opts.buttons.filter(b => b.role === "cancel").length;
+    const defaultCount = opts.buttons.filter(b => b.role === "default").length;
 
     if (cancelCount > 1) {
       throw Error(`${cancelCount} cancel buttons found.`);
@@ -102,7 +100,8 @@ export function appIpcs(
       title: opts.title,
       type: opts.type ?? "info",
       message: opts.text,
-      buttons: opts.buttons.map((b) => b.text),
+      detail: opts.detail,
+      buttons: opts.buttons.map(b => b.text),
     });
 
     // Return back the button that was selected.
@@ -127,7 +126,7 @@ export function appIpcs(
   });
 
   ipc.handle("app.quit", async () => {
-    BrowserWindow.getAllWindows().forEach((w) => w.close());
+    BrowserWindow.getAllWindows().forEach(w => w.close());
   });
 
   ipc.handle("app.inspectElement", async (_, coord) => {
@@ -138,7 +137,7 @@ export function appIpcs(
     BrowserWindow.getFocusedWindow()?.webContents.inspectElement(
       // Coords can come over as floats
       Math.round(coord.x),
-      Math.round(coord.y)
+      Math.round(coord.y),
     );
   });
 
@@ -151,7 +150,7 @@ export function appIpcs(
 
 export function buildMenus(
   menus: MenuType[],
-  channel: IpcChannel
+  channel: IpcChannel,
 ): MenuItemConstructorOptions[] {
   // We don't listen for shortcuts in the application menu because we
   // already listen for them in the renderer thread and this will cause
@@ -239,7 +238,7 @@ export function buildMenus(
 export function buildClickHandler<Ev extends UIEventType>(
   event: Ev,
   eventInput: UIEventInput<Ev>,
-  channel: IpcChannel
+  channel: IpcChannel,
 ): MenuItemConstructorOptions["click"] {
   return (_, browserWindow) => {
     browserWindow?.webContents.send(channel, {

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -9,7 +9,11 @@ import { isRoleMenu, Menu as MenuType } from "../shared/ui/menu";
 import { IpcChannel, IpcMainTS } from "../shared/ipc";
 import { openInBrowser } from "./utils";
 import { UIEventType, UIEventInput } from "../shared/ui/events";
-import { AppState, DEFAULT_SIDEBAR_WIDTH } from "../shared/ui/app";
+import {
+  AppState,
+  DEFAULT_SIDEBAR_WIDTH,
+  SerializedAppState,
+} from "../shared/ui/app";
 
 import { JsonFile, loadJsonFile } from "./json";
 import { Config } from "../shared/domain/config";
@@ -26,14 +30,14 @@ export function appIpcs(
   config: JsonFile<Config>,
   log: Logger,
 ): void {
-  let appStateFile: JsonFile<AppState>;
+  let appStateFile: JsonFile<SerializedAppState>;
 
   ipc.on("init", async () => {
     if (config.content.dataDirectory == null) {
       throw new MissingDataDirectoryError();
     }
 
-    appStateFile = await loadJsonFile<AppState>(
+    appStateFile = await loadJsonFile<SerializedAppState>(
       p.join(config.content.dataDirectory, APP_STATE_PATH),
       APP_STATE_SCHEMAS,
       {

--- a/src/main/app.ts
+++ b/src/main/app.ts
@@ -9,11 +9,7 @@ import { isRoleMenu, Menu as MenuType } from "../shared/ui/menu";
 import { IpcChannel, IpcMainTS } from "../shared/ipc";
 import { openInBrowser } from "./utils";
 import { UIEventType, UIEventInput } from "../shared/ui/events";
-import {
-  AppState,
-  DEFAULT_SIDEBAR_WIDTH,
-  SerializedAppState,
-} from "../shared/ui/app";
+import { DEFAULT_SIDEBAR_WIDTH, SerializedAppState } from "../shared/ui/app";
 
 import { JsonFile, loadJsonFile } from "./json";
 import { Config } from "../shared/domain/config";

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,7 +11,7 @@ import { getLogger, logIpcs } from "./log";
 
 if (!isTest() && getProcessType() !== "main") {
   throw Error(
-    "ipcMain is null. Did you accidentally import main.ts in the renderer thread?"
+    "ipcMain is null. Did you accidentally import main.ts in the renderer thread?",
   );
 }
 
@@ -24,119 +24,126 @@ declare const MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY: string;
 let mainWindow: BrowserWindow;
 
 export async function main(): Promise<void> {
-  const configFile = await getConfig();
-  const log = await getLogger(configFile, console);
+  try {
+    const configFile = await getConfig();
+    const log = await getLogger(configFile, console);
 
-  const typeSafeIpc = ipcMain as IpcMainTS;
-  logIpcs(typeSafeIpc, configFile, log);
-  configIpcs(typeSafeIpc, configFile, log);
-  appIpcs(typeSafeIpc, configFile, log);
-  shortcutIpcs(typeSafeIpc, configFile, log);
-  noteIpcs(typeSafeIpc, configFile, log);
+    const typeSafeIpc = ipcMain as IpcMainTS;
+    logIpcs(typeSafeIpc, configFile, log);
+    configIpcs(typeSafeIpc, configFile, log);
+    appIpcs(typeSafeIpc, configFile, log);
+    shortcutIpcs(typeSafeIpc, configFile, log);
+    noteIpcs(typeSafeIpc, configFile, log);
 
-  // Handle creating/removing shortcuts on Windows when installing/uninstalling.
-  if (require("electron-squirrel-startup")) {
-    app.quit();
-  }
-
-  const createWindow = async (): Promise<void> => {
-    await initPlugins(typeSafeIpc);
-
-    // Only allow external images
-    session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
-      callback({
-        responseHeaders: Object.assign(
-          {
-            ...details.responseHeaders,
-            "Content-Security-Policy": ["img-src *"],
-          },
-          details.responseHeaders
-        ),
-      });
-    });
-
-    let { windowHeight, windowWidth } = configFile.content;
-    mainWindow = new BrowserWindow({
-      height: windowHeight,
-      width: windowWidth,
-      icon: "static/icon.png",
-      webPreferences: {
-        preload: MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY,
-        // Do not change these. They are for security purposes.
-        nodeIntegration: false,
-        contextIsolation: true,
-      },
-    });
-
-    // and load the index.html of the app.
-    mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
-
-    if (isDevelopment()) {
-      mainWindow.webContents.openDevTools();
-    }
-
-    mainWindow.on("resize", async () => {
-      const [width, height] = mainWindow.getSize();
-      windowHeight = height;
-      windowWidth = width;
-
-      await configFile.update({
-        windowHeight,
-        windowWidth,
-      });
-    });
-
-    // Override how all links are open so we can send them off to the user's
-    // web browser instead of opening them in the electron app.
-    mainWindow.webContents.setWindowOpenHandler((details) => {
-      openInBrowser(details.url);
-      return { action: "deny" };
-    });
-
-    // We set a non-functional application menu at first so we can make things
-    // appear to load smoother visually. Once renderer has started we'll
-    // populate it with an actual menu.
-    mainWindow.setMenu(
-      Menu.buildFromTemplate([
-        { label: "File", enabled: false },
-        { label: "Edit", enabled: false },
-        { label: "View", enabled: false },
-      ])
-    );
-  };
-
-  // Quit when all windows are closed, except on macOS. There, it's common
-  // for applications and their menu bar to stay active until the user quits
-  // explicitly with Cmd + Q.
-  app.on("window-all-closed", () => {
-    if (process.platform !== "darwin") {
+    // Handle creating/removing shortcuts on Windows when installing/uninstalling.
+    if (require("electron-squirrel-startup")) {
       app.quit();
     }
-  });
 
-  app.on("activate", () => {
-    // On OS X it's common to re-create a window in the app when the
-    // dock icon is clicked and there are no other windows open.
-    if (BrowserWindow.getAllWindows().length === 0) {
-      createWindow();
+    const createWindow = async (): Promise<void> => {
+      await initPlugins(typeSafeIpc);
+
+      // Only allow external images
+      session.defaultSession.webRequest.onHeadersReceived(
+        (details, callback) => {
+          callback({
+            responseHeaders: Object.assign(
+              {
+                ...details.responseHeaders,
+                "Content-Security-Policy": ["img-src *"],
+              },
+              details.responseHeaders,
+            ),
+          });
+        },
+      );
+
+      let { windowHeight, windowWidth } = configFile.content;
+      mainWindow = new BrowserWindow({
+        height: windowHeight,
+        width: windowWidth,
+        icon: "static/icon.png",
+        webPreferences: {
+          preload: MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY,
+          // Do not change these. They are for security purposes.
+          nodeIntegration: false,
+          contextIsolation: true,
+        },
+      });
+
+      // and load the index.html of the app.
+      mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
+
+      if (isDevelopment()) {
+        mainWindow.webContents.openDevTools();
+      }
+
+      mainWindow.on("resize", async () => {
+        const [width, height] = mainWindow.getSize();
+        windowHeight = height;
+        windowWidth = width;
+
+        await configFile.update({
+          windowHeight,
+          windowWidth,
+        });
+      });
+
+      // Override how all links are open so we can send them off to the user's
+      // web browser instead of opening them in the electron app.
+      mainWindow.webContents.setWindowOpenHandler(details => {
+        openInBrowser(details.url);
+        return { action: "deny" };
+      });
+
+      // We set a non-functional application menu at first so we can make things
+      // appear to load smoother visually. Once renderer has started we'll
+      // populate it with an actual menu.
+      mainWindow.setMenu(
+        Menu.buildFromTemplate([
+          { label: "File", enabled: false },
+          { label: "Edit", enabled: false },
+          { label: "View", enabled: false },
+        ]),
+      );
+    };
+
+    // Quit when all windows are closed, except on macOS. There, it's common
+    // for applications and their menu bar to stay active until the user quits
+    // explicitly with Cmd + Q.
+    app.on("window-all-closed", () => {
+      if (process.platform !== "darwin") {
+        app.quit();
+      }
+    });
+
+    app.on("activate", async () => {
+      // On OS X it's common to re-create a window in the app when the
+      // dock icon is clicked and there are no other windows open.
+      if (BrowserWindow.getAllWindows().length === 0) {
+        await createWindow();
+      }
+    });
+
+    app.on("quit", () => {
+      log.close();
+
+      // Use console.log() over log.info to avoid appending this to the log file
+      // eslint-disable-next-line no-console
+      console.log(`Shutting down. Log saved to: ${log.filePath}`);
+    });
+
+    // Ready event might fire before we finish loading our config file causing us
+    // to miss it.
+    // Source: https://github.com/electron/electron/issues/12557
+    if (app.isReady()) {
+      await createWindow();
+    } else {
+      app.on("ready", createWindow);
     }
-  });
-
-  app.on("quit", () => {
-    log.close();
-
-    // Use console.log() over log.info to avoid appending this to the log file
-    // eslint-disable-next-line no-console
-    console.log(`Shutting down. Log saved to: ${log.filePath}`);
-  });
-
-  // Ready event might fire before we finish loading our config file causing us
-  // to miss it.
-  // Source: https://github.com/electron/electron/issues/12557
-  if (app.isReady()) {
-    createWindow();
-  } else {
-    app.on("ready", createWindow);
+  } catch (err) {
+    console.error("Error: Failed to initialize app.");
+    console.error(err);
   }
 }
 
@@ -147,5 +154,5 @@ if (!isTest()) {
 
 export async function initPlugins(typeSafeIpc: IpcMainTS): Promise<unknown> {
   const initListeners = typeSafeIpc.listeners("init");
-  return await Promise.all(initListeners.map((l) => l()));
+  return await Promise.all(initListeners.map(l => l()));
 }

--- a/src/main/json.ts
+++ b/src/main/json.ts
@@ -25,7 +25,11 @@ export async function writeJson<Content extends Versioned>(
     content.version = version;
   }
 
-  await schema.parseAsync(content);
+  if (content == null) {
+    throw new Error("No content passed.");
+  }
+
+  content = await schema.parseAsync(content);
 
   const serialized = JSON.stringify(content, null, 2);
   await fsp.writeFile(filePath, serialized, { encoding: "utf-8" });

--- a/src/main/log.ts
+++ b/src/main/log.ts
@@ -1,10 +1,5 @@
 /* eslint-disable no-console */
-import {
-  differenceInCalendarDays,
-  format,
-  formatISO,
-  parseISO,
-} from "date-fns";
+import { differenceInCalendarDays, format, formatISO } from "date-fns";
 import { Config } from "../shared/domain/config";
 import { IpcMainTS } from "../shared/ipc";
 import { Logger } from "../shared/logger";
@@ -38,8 +33,8 @@ export function logIpcs(
     log.warn(`[RENDERER] ${message}`),
   );
 
-  ipc.handle("log.error", async (_, message) =>
-    log.error(`[RENDERER] ${message}`),
+  ipc.handle("log.error", async (_, message, err) =>
+    log.error(`[RENDERER] ${message}`, err),
   );
 }
 
@@ -87,19 +82,19 @@ export async function getLogger(
       const fullMessage = `${getTimeStamp()} (info): ${message}`;
       c.log(fullMessage);
 
-      await fileStream.write(fullMessage + os.EOL);
+      fileStream.write(fullMessage + os.EOL);
     },
     async warn(message: string): Promise<void> {
       const fullMessage = `${getTimeStamp()} (warn): ${message}`;
       c.warn(chalk.yellow(fullMessage));
 
-      await fileStream.write(fullMessage + os.EOL);
+      fileStream.write(fullMessage + os.EOL);
     },
     async error(message: string): Promise<void> {
       const fullMessage = `${getTimeStamp()} (ERROR): ${message}`;
-      c.error(chalk.red(fullMessage));
 
-      await fileStream.write(fullMessage + os.EOL);
+      c.error(chalk.red(fullMessage));
+      fileStream.write(fullMessage + os.EOL);
     },
   };
 

--- a/src/main/notes.ts
+++ b/src/main/notes.ts
@@ -1,38 +1,51 @@
-import { createNote, flatten, getNoteById, Note } from "../shared/domain/note";
+import { createNote, Note, NoteSort } from "../shared/domain/note";
 import { UUID_REGEX } from "../shared/domain";
 import { Config } from "../shared/domain/config";
-import { cloneDeep, keyBy, omit, partition } from "lodash";
+import { cloneDeep, difference, keyBy, omit, partition } from "lodash";
 import { shell } from "electron";
-import { IpcMainTS } from "../shared/ipc";
+import { IpcMainTS, NoteUpdateParams } from "../shared/ipc";
 import * as fs from "fs";
 import * as fsp from "fs/promises";
 import { JsonFile, loadJson, writeJson } from "./json";
 import * as p from "path";
 import { Logger } from "../shared/logger";
 import { NOTE_SCHEMAS } from "./schemas/notes";
+import { z } from "zod";
+import { isDevelopment } from "../shared/env";
 
 export const NOTES_DIRECTORY = "notes";
 export const METADATA_FILE_NAME = "metadata.json";
 export const MARKDOWN_FILE_NAME = "index.md";
 
+const noteUpdateSchema: z.Schema<NoteUpdateParams> = z.object({
+  name: z.string().optional(),
+  parent: z.string().optional(),
+  sort: z.nativeEnum(NoteSort).optional(),
+  content: z.string().optional(),
+});
+
 export function noteIpcs(
   ipc: IpcMainTS,
   config: JsonFile<Config>,
   log: Logger,
-  // Only use this for testing.
-  _notes: Note[] = [],
 ): void {
   const { dataDirectory } = config.content;
   if (dataDirectory == null) {
+    log.debug("No data directory specified. Skipping registering note ipcs.");
     return;
   }
-
-  let notes: Note[] = _notes;
+  const noteDirectory = p.join(dataDirectory, NOTES_DIRECTORY);
+  let noteRelationships: NoteRelationship[] = [];
 
   ipc.on("init", async () => {
-    const noteDirectory = p.join(dataDirectory, NOTES_DIRECTORY);
     if (!fs.existsSync(noteDirectory)) {
       await fsp.mkdir(noteDirectory);
+    }
+  });
+
+  ipc.handle("notes.getAll", async () => {
+    if (!fs.existsSync(noteDirectory)) {
+      return [];
     }
 
     const entries = await fsp.readdir(noteDirectory, { withFileTypes: true });
@@ -43,195 +56,117 @@ export function noteIpcs(
         continue;
       }
 
-      const path = p.join(noteDirectory, entry.name, METADATA_FILE_NAME);
-      const json = await loadJson<Note>(path, NOTE_SCHEMAS);
+      const note = await loadNoteFromFS(noteDirectory, entry.name);
 
       // The order notes are loaded in is not guaranteed so we store them in a flat
       // array until we've loaded every last one before we start to rebuild their
       // family trees.
-      everyNote.push(json);
+      everyNote.push({ ...note, children: [] });
     }
 
-    notes = buildNoteTree(everyNote);
-  });
-
-  ipc.handle("notes.getAll", async () => {
+    const [notes, relationships] = buildNoteTree(everyNote);
+    noteRelationships = relationships;
     return notes;
   });
 
-  ipc.handle("notes.create", async (_, name, parentId) => {
-    const note = createNote({
-      name,
-      parent: parentId,
-    });
+  ipc.handle("notes.create", async (_, params) => {
+    const note = createNote(params);
+    await saveNoteToFS(noteDirectory, note);
 
-    const dirPath = p.join(dataDirectory, NOTES_DIRECTORY, note.id);
-    if (!fs.existsSync(dirPath)) {
-      await fsp.mkdir(dirPath);
-    }
-
-    const metadataPath = p.join(
-      dataDirectory,
-      NOTES_DIRECTORY,
-      note.id,
-      METADATA_FILE_NAME,
-    );
-    const markdownPath = p.join(
-      dataDirectory,
-      NOTES_DIRECTORY,
-      note.id,
-      MARKDOWN_FILE_NAME,
-    );
-
-    await writeJson(metadataPath, NOTE_SCHEMAS, omit(note, "children"));
-
-    const s = await fsp.open(markdownPath, "w");
-    await s.close();
-
-    // TODO: Clean this up when we refactor
-    // Bust the cache
-    if (parentId == null) {
-      notes.push(note);
-    } else {
-      const parentNote = getNoteById(notes, parentId);
-      parentNote.children ??= [];
-      parentNote.children.push(note);
+    if (params.parent != null) {
+      noteRelationships.push([params.parent, note.id]);
     }
 
     return note;
   });
 
-  ipc.handle("notes.updateMetadata", async (_, id, props) => {
-    const note = getNoteById(notes, id);
+  ipc.handle("notes.update", async (_, id, props) => {
+    const note: NoteFile = await loadNoteFromFS(noteDirectory, id);
+    const update = await noteUpdateSchema.parseAsync(props);
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { name, parent, sort, ...others } = props;
-
-    if (name != null) {
-      note.name = name;
+    if (update.name != null) {
+      note.name = update.name;
     }
 
     // Allow unsetting parent
-    if ("parent" in props) {
-      note.parent = parent;
+    if ("parent" in update) {
+      note.parent = update.parent;
 
-      // Bust the cache on parent change
-      const flattened = flatten(notes);
-      notes = buildNoteTree(flattened);
+      // TODO: Can we change this? I don't like that if saving to the fs fails
+      // we've put our note map in an incorrect state.
+      const relationship = noteRelationships.find(r => r[1] === note.id);
+      if (relationship) {
+        relationship[0] = note.parent!;
+      }
     }
 
     // Allow unsetting sort
-    if ("sort" in props) {
-      note.sort = props.sort;
+    if ("sort" in update) {
+      note.sort = update.sort;
+    }
+
+    if (update.content != null) {
+      note.content = update.content;
     }
 
     // Sanity check to ensure no extra props were passed
-    if (Object.keys(others).length > 0) {
-      console.warn(
-        `ipc notes.updateMetadata does not support keys: ${Object.keys(
-          others,
-        )}`,
-      );
+    if (
+      isDevelopment() &&
+      Object.keys(props).length > Object.keys(update).length
+    ) {
+      const diff = difference(Object.keys(props), Object.keys(update));
+      log.warn(`ipc notes.update does not support keys: ${diff.join(", ")}`);
     }
 
     note.dateUpdated = new Date();
-    const meta = omit(note, "children");
-    const path = p.join(dataDirectory, NOTES_DIRECTORY, id, METADATA_FILE_NAME);
-    writeJson(path, NOTE_SCHEMAS, meta);
-
-    return note;
-  });
-
-  ipc.handle("notes.loadContent", async (_, id) => {
-    const markdownPath = p.join(
-      dataDirectory,
-      NOTES_DIRECTORY,
-      id,
-      MARKDOWN_FILE_NAME,
-    );
-    return (await fsp.readFile(markdownPath, { encoding: "utf-8" })) ?? "";
-  });
-
-  ipc.handle("notes.saveContent", async (_, id, content) => {
-    const markdownPath = p.join(
-      dataDirectory,
-      NOTES_DIRECTORY,
-      id,
-      MARKDOWN_FILE_NAME,
-    );
-    await fsp.writeFile(markdownPath, content, { encoding: "utf-8" });
-
-    const note = getNoteById(notes, id);
-    note.dateUpdated = new Date();
-    const metaDataPath = p.join(
-      dataDirectory,
-      NOTES_DIRECTORY,
-      id,
-      METADATA_FILE_NAME,
-    );
-    writeJson(metaDataPath, NOTE_SCHEMAS, note);
+    await saveNoteToFS(noteDirectory, note);
   });
 
   ipc.handle("notes.delete", async (_, id) => {
-    const note = getNoteById(notes, id);
-
-    const recursive = async (n: Note) => {
-      const notePath = p.join(dataDirectory, NOTES_DIRECTORY, n.id);
-      // N.B. fsp.rm doesn't exist in 14.10 but typings include it.
+    const recursive = async (noteId: string) => {
+      const notePath = p.join(noteDirectory, noteId);
+      // fsp.rm doesn't exist in 14.10 but typings include it.
+      // TODO: switch to rm when we upgrade from Node 14.10.
       await fsp.rmdir(notePath, { recursive: true });
 
-      for (const child of n.children ?? []) {
-        await recursive(child);
+      const children = noteRelationships.filter(r => r[0] === noteId);
+      noteRelationships = noteRelationships.filter(r => !children.includes(r));
+
+      for (const relationship of children) {
+        await recursive(relationship[1]);
       }
     };
-    await recursive(note);
-
-    if (note.parent == null) {
-      notes = notes.filter(n => n.id !== note.id);
-    } else {
-      const parentNote = getNoteById(notes, note.parent);
-      if (parentNote != null && parentNote.children != null) {
-        parentNote.children = parentNote.children.filter(c => c.id !== note.id);
-      }
-    }
+    await recursive(id);
   });
 
   ipc.handle("notes.moveToTrash", async (_, id) => {
-    const note = getNoteById(notes, id);
-
-    const recursive = async (n: Note) => {
-      const notePath = p.join(dataDirectory, NOTES_DIRECTORY, n.id);
+    const recursive = async (noteId: string) => {
+      const notePath = p.join(noteDirectory, noteId);
       await shell.trashItem(notePath);
 
-      for (const child of n.children ?? []) {
-        await recursive(child);
+      const children = noteRelationships.filter(r => r[0] === noteId);
+      noteRelationships = noteRelationships.filter(r => !children.includes(r));
+
+      for (const relationship of children) {
+        await recursive(relationship[1]);
       }
     };
-
-    await recursive(note);
-
-    if (note.parent == null) {
-      notes = notes.filter(n => n.id !== note.id);
-    } else {
-      const parentNote = getNoteById(notes, note.parent);
-      if (parentNote != null && parentNote.children != null) {
-        parentNote.children = parentNote.children.filter(c => c.id !== note.id);
-      }
-    }
+    await recursive(id);
   });
 }
 
-export function buildNoteTree(flattened: Note[]): Note[] {
-  const clonedFlattened = cloneDeep(flattened);
+type NoteRelationship = [string, string];
 
+export function buildNoteTree(flattened: Note[]): [Note[], NoteRelationship[]] {
   // We nuke children to prevent duplicates when we rebuild the tree.
-  for (const clone of clonedFlattened) {
-    clone.children = [];
-  }
-
-  const lookup = keyBy(clonedFlattened, "id");
-
+  const clonedFlattened = cloneDeep(flattened).map(c => ({
+    ...c,
+    children: [],
+  }));
   const [roots, nested] = partition(clonedFlattened, n => n.parent == null);
+  const lookup = keyBy<Note>(clonedFlattened, "id");
+  const relationships: NoteRelationship[] = [];
+
   for (const n of nested) {
     const parent = lookup[n.parent!];
     if (parent == null) {
@@ -240,9 +175,58 @@ export function buildNoteTree(flattened: Note[]): Note[] {
       );
     }
 
-    parent.children ??= [];
     parent.children.push(n);
+    relationships.push([parent.id, n.id]);
   }
 
-  return roots;
+  return [roots, relationships];
+}
+
+export type NoteMetadata = Omit<Note, "content" | "children">;
+export type NoteMarkdown = Pick<Note, "content">;
+export type NoteFile = NoteMetadata & NoteMarkdown;
+
+export async function saveNoteToFS(
+  noteDirectoryPath: string,
+  note: NoteFile,
+): Promise<void> {
+  const notePath = p.join(noteDirectoryPath, note.id);
+  if (!fs.existsSync(notePath)) {
+    await fsp.mkdir(notePath);
+  }
+
+  const metadataPath = p.join(notePath, METADATA_FILE_NAME);
+  const markdownPath = p.join(notePath, MARKDOWN_FILE_NAME);
+
+  const [metadata, content] = splitNoteIntoFiles(note);
+  await writeJson(metadataPath, NOTE_SCHEMAS, metadata);
+
+  if (!fs.existsSync(markdownPath)) {
+    const s = await fsp.open(markdownPath, "w");
+    await s.write(content, null, "utf-8");
+    await s.close();
+  } else {
+    await fs.promises.writeFile(markdownPath, content, {
+      encoding: "utf-8",
+    });
+  }
+}
+
+export async function loadNoteFromFS(
+  noteDirectoryPath: string,
+  noteId: string,
+): Promise<NoteFile> {
+  const metadataPath = p.join(noteDirectoryPath, noteId, METADATA_FILE_NAME);
+  const note = await loadJson<Note>(metadataPath, NOTE_SCHEMAS);
+
+  const markdownPath = p.join(noteDirectoryPath, noteId, MARKDOWN_FILE_NAME);
+  const markdown = await fsp.readFile(markdownPath, { encoding: "utf-8" });
+  note.content = markdown;
+
+  return note;
+}
+
+export function splitNoteIntoFiles(note: NoteFile): [NoteMetadata, string] {
+  const metadata: NoteMetadata = omit(note, "content", "children");
+  return [metadata, note.content];
 }

--- a/src/main/schemas/appState/1_initialDefinition.ts
+++ b/src/main/schemas/appState/1_initialDefinition.ts
@@ -1,9 +1,10 @@
 import { z } from "zod";
-import { DATE_OR_STRING_SCHEMA } from "../../../shared/domain";
+import { DATE_OR_STRING_SCHEMA, PX_REGEX } from "../../../shared/domain";
 import { NoteSort } from "../../../shared/domain/note";
 import { Section } from "../../../shared/ui/app";
 
-interface AppStateV1 {
+export interface AppStateV1 {
+  version: number;
   sidebar: Sidebar;
   editor: Editor;
   focused: Section[];
@@ -36,7 +37,7 @@ interface EditorTab {
 export const appStateV1: z.Schema<AppStateV1> = z.object({
   version: z.literal(1),
   sidebar: z.object({
-    width: z.string().regex(/^\d+px$/),
+    width: z.string().regex(PX_REGEX),
     scroll: z.number(),
     hidden: z.boolean().optional(),
     selected: z.array(z.string()).optional(),
@@ -51,7 +52,7 @@ export const appStateV1: z.Schema<AppStateV1> = z.object({
         noteId: z.string(),
         // Intentionally omitted noteContent
         lastActive: DATE_OR_STRING_SCHEMA.optional(),
-      })
+      }),
     ),
     tabsScroll: z.number(),
     activeTabNoteId: z.string().optional(),

--- a/src/main/schemas/utils.ts
+++ b/src/main/schemas/utils.ts
@@ -1,0 +1,14 @@
+import { max } from "lodash";
+import { z } from "zod";
+
+export function getLatestSchemaVersion(
+  schemas: Record<number, z.ZodSchema<unknown>>,
+): number {
+  const keys = Object.keys(schemas).map(k => Number.parseInt(k, 10));
+
+  if (keys.length === 0) {
+    throw new Error(`Schema object was empty.`);
+  }
+
+  return max(keys)!;
+}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -55,7 +55,6 @@ export function App(props: AppProps): JSX.Element {
   const { config } = props;
   const store = useStore(props.state);
   const { state } = store;
-  const { sidebar, editor } = state;
 
   useShortcuts(store);
   useApplicationMenu(store, config);
@@ -111,20 +110,6 @@ export function App(props: AppProps): JSX.Element {
   }, [store]);
 
   useFocusTracking(store);
-
-  // Load the content of any notes that were previously open.
-  useEffect(() => {
-    const tabsToLoad = editor.tabs
-      .filter(t => t.noteContent == null)
-      .map(t => t.noteId);
-
-    if (tabsToLoad.length > 0) {
-      store.dispatch("editor.openTab", {
-        note: tabsToLoad,
-        active: editor.activeTabNoteId ?? first(sidebar.selected),
-      });
-    }
-  }, [editor.tabs, editor.activeTabNoteId, store, sidebar.selected]);
 
   return (
     <Container>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -9,7 +9,6 @@ import {
   filterOutStaleNoteIds,
   Section,
   SerializedAppState,
-  SerializedEditorTab,
 } from "../shared/ui/app";
 import { Shortcut } from "../shared/domain/shortcut";
 import { getNoteById, Note } from "../shared/domain/note";
@@ -22,7 +21,6 @@ import { useApplicationMenu } from "./menus/appMenu";
 import { useContextMenu } from "./menus/contextMenu";
 import { Editor } from "./components/Editor";
 import { h100, HEADER_SIZES, mb2, w100 } from "./css";
-import { AppState } from "../shared/ui/app";
 import { Config } from "../shared/domain/config";
 import { log } from "./logger";
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -9,7 +9,7 @@ import { Shortcut } from "../shared/domain/shortcut";
 import { Note } from "../shared/domain/note";
 import { State, Listener, useStore } from "./store";
 import { isTest } from "../shared/env";
-import { first, isEmpty, tail } from "lodash";
+import { isEmpty, tail } from "lodash";
 import { DataDirectoryModal } from "./components/DataDirectoryModal";
 import styled from "styled-components";
 import { useApplicationMenu } from "./menus/appMenu";
@@ -29,9 +29,8 @@ async function main() {
     config = await ipc("config.get");
     initialState = await loadInitialState();
   } catch (e) {
-    console.error("Fatal Error", e);
-    await promptFatal((e as Error).message);
-    ipc("app.quit");
+    await log.error("Fatal: Failed to initialize the app.", e as Error);
+    await promptFatal("Failed to initialize app.", e as Error);
     return;
   }
 

--- a/src/renderer/components/Editor.tsx
+++ b/src/renderer/components/Editor.tsx
@@ -101,7 +101,7 @@ const setContent: Listener<"editor.setContent"> = async ({ value }, ctx) => {
     };
   });
 
-  await debouncedInvoker("notes.saveContent", noteId, content);
+  await debouncedInvoker("notes.update", noteId, { content });
 };
 
 const toggleView: Listener<"editor.toggleView"> = (_, ctx) => {

--- a/src/renderer/components/Editor.tsx
+++ b/src/renderer/components/Editor.tsx
@@ -1,16 +1,14 @@
-import { debounce, head, isEmpty, last, tail } from "lodash";
+import { debounce } from "lodash";
 import React, { useEffect } from "react";
 import styled from "styled-components";
-import { EditorTab, Section } from "../../shared/ui/app";
+import { Section } from "../../shared/ui/app";
 import { Ipc } from "../../shared/ipc";
 import { m2 } from "../css";
 import { Listener, Store } from "../store";
 import { Markdown } from "./Markdown";
 import { Monaco } from "./Monaco";
 import { Focusable } from "./shared/Focusable";
-import { getNoteById } from "../../shared/domain/note";
 import { EditorTabs, TABS_HEIGHT } from "./EditorTabs";
-import * as monaco from "monaco-editor";
 
 const NOTE_SAVE_INTERVAL_MS = 500;
 
@@ -25,7 +23,7 @@ export function Editor(props: EditorProps): JSX.Element {
 
   let activeTab;
   if (editor.activeTabNoteId != null) {
-    activeTab = editor.tabs.find((t) => t.noteId === editor.activeTabNoteId);
+    activeTab = editor.tabs.find(t => t.note.id === editor.activeTabNoteId);
   }
 
   let content;
@@ -35,11 +33,9 @@ export function Editor(props: EditorProps): JSX.Element {
     content = (
       <Markdown
         store={store}
-        content={activeTab?.noteContent ?? ""}
+        content={activeTab?.note.content ?? ""}
         scroll={state.editor.scroll}
-        onScroll={(newVal) =>
-          void store.dispatch("editor.updateScroll", newVal)
-        }
+        onScroll={newVal => void store.dispatch("editor.updateScroll", newVal)}
       />
     );
   }
@@ -81,7 +77,7 @@ const StyledContent = styled.div`
 
 const debouncedInvoker = debounce(
   window.ipc,
-  NOTE_SAVE_INTERVAL_MS
+  NOTE_SAVE_INTERVAL_MS,
 ) as unknown as Ipc;
 
 const setContent: Listener<"editor.setContent"> = async ({ value }, ctx) => {
@@ -91,12 +87,12 @@ const setContent: Listener<"editor.setContent"> = async ({ value }, ctx) => {
 
   const { noteId, content } = value;
 
-  ctx.setUI((prev) => {
+  ctx.setUI(prev => {
     const index = prev.editor.tabs.findIndex(
-      (t) => t.noteId === prev.editor.activeTabNoteId
+      t => t.note.id === prev.editor.activeTabNoteId,
     );
     // Update local cache for renderer
-    prev.editor.tabs[index].noteContent = content;
+    prev.editor.tabs[index].note.content = content;
 
     return {
       editor: {
@@ -143,7 +139,7 @@ const save: Listener<"editor.save"> = (_, ctx) => {
 
 export const updateScroll: Listener<"editor.updateScroll"> = (
   { value: scroll },
-  ctx
+  ctx,
 ) => {
   if (scroll == null) {
     throw Error();

--- a/src/renderer/components/Editor.tsx
+++ b/src/renderer/components/Editor.tsx
@@ -9,6 +9,7 @@ import { Markdown } from "./Markdown";
 import { Monaco } from "./Monaco";
 import { Focusable } from "./shared/Focusable";
 import { EditorTabs, TABS_HEIGHT } from "./EditorTabs";
+import { getNoteById } from "../../shared/domain/note";
 
 const NOTE_SAVE_INTERVAL_MS = 500;
 
@@ -93,12 +94,17 @@ const setContent: Listener<"editor.setContent"> = async ({ value }, ctx) => {
     );
     // Update local cache for renderer
     prev.editor.tabs[index].note.content = content;
-
     return {
       editor: {
         tabs: [...prev.editor.tabs],
       },
     };
+  });
+
+  ctx.setNotes(notes => {
+    const note = getNoteById(notes, noteId);
+    note.content = content;
+    return [...notes];
   });
 
   await debouncedInvoker("notes.update", noteId, { content });

--- a/src/renderer/components/EditorTabs.tsx
+++ b/src/renderer/components/EditorTabs.tsx
@@ -35,7 +35,7 @@ export function EditorTabs(props: EditorTabsProps): JSX.Element {
     };
 
     for (const tab of editor.tabs) {
-      const note = getNoteById(notes, tab.noteId);
+      const note = getNoteById(notes, tab.note.id);
 
       rendered.push(
         <EditorTab
@@ -66,7 +66,7 @@ export function EditorTabs(props: EditorTabsProps): JSX.Element {
     }
 
     const currentIndex = tabsByLastActive.findIndex(
-      t => t.noteId === editor.activeTabNoteId,
+      t => t.note.id === editor.activeTabNoteId,
     );
 
     let previousIndex = (currentIndex - 1) % tabsByLastActive.length;
@@ -88,7 +88,7 @@ export function EditorTabs(props: EditorTabsProps): JSX.Element {
 
       ctx.setUI({
         editor: {
-          activeTabNoteId: nextTab?.noteId,
+          activeTabNoteId: nextTab?.note.id,
         },
       });
     },
@@ -103,7 +103,7 @@ export function EditorTabs(props: EditorTabsProps): JSX.Element {
 
       ctx.setUI({
         editor: {
-          activeTabNoteId: previousTab?.noteId,
+          activeTabNoteId: previousTab?.note.id,
         },
       });
     },
@@ -123,13 +123,13 @@ export function EditorTabs(props: EditorTabsProps): JSX.Element {
 
     switch (type) {
       case "editor.closeAllTabs":
-        noteIdsToClose = editor.tabs.map(t => t.noteId);
+        noteIdsToClose = editor.tabs.map(t => t.note.id);
         break;
 
       case "editor.closeOtherTabs":
         noteIdsToClose = editor.tabs
-          .filter(t => t.noteId !== (value ?? editor.activeTabNoteId))
-          .map(t => t.noteId);
+          .filter(t => t.note.id !== (value ?? editor.activeTabNoteId))
+          .map(t => t.note.id);
         break;
 
       case "editor.closeTab":
@@ -142,18 +142,18 @@ export function EditorTabs(props: EditorTabsProps): JSX.Element {
 
       case "editor.closeTabsToLeft": {
         const leftLimit = editor.tabs.findIndex(
-          t => t.noteId === (value ?? editor.activeTabNoteId),
+          t => t.note.id === (value ?? editor.activeTabNoteId),
         );
-        noteIdsToClose = editor.tabs.slice(0, leftLimit).map(t => t.noteId);
+        noteIdsToClose = editor.tabs.slice(0, leftLimit).map(t => t.note.id);
         break;
       }
 
       case "editor.closeTabsToRight": {
         const rightLimit = editor.tabs.findIndex(
-          t => t.noteId === (value ?? editor.activeTabNoteId),
+          t => t.note.id === (value ?? editor.activeTabNoteId),
         );
 
-        noteIdsToClose = editor.tabs.slice(rightLimit + 1).map(t => t.noteId);
+        noteIdsToClose = editor.tabs.slice(rightLimit + 1).map(t => t.note.id);
         break;
       }
 
@@ -163,7 +163,7 @@ export function EditorTabs(props: EditorTabsProps): JSX.Element {
 
     ctx.setUI(prev => {
       const tabs = prev.editor.tabs.filter(
-        t => !noteIdsToClose.includes(t.noteId),
+        t => !noteIdsToClose.includes(t.note.id),
       );
 
       let activeTabNoteId: string | undefined;
@@ -174,12 +174,12 @@ export function EditorTabs(props: EditorTabsProps): JSX.Element {
 
         case "editor.closeTab": {
           const tabsByLastActive = orderBy(
-            editor.tabs.filter(t => !noteIdsToClose.includes(t.noteId)),
+            editor.tabs.filter(t => !noteIdsToClose.includes(t.note.id)),
             ["lastActive"],
             ["desc"],
           );
 
-          activeTabNoteId = tabsByLastActive[0]?.noteId;
+          activeTabNoteId = tabsByLastActive[0]?.note.id;
           break;
         }
 
@@ -408,15 +408,13 @@ export const openTab: Listener<"editor.openTab"> = async (ev, ctx) => {
 
   for (const noteId of noteIds) {
     let newTab = false;
-    let tab = editor.tabs.find(t => t.noteId === noteId);
+    let tab = editor.tabs.find(t => t.note.id === noteId);
 
     if (tab == null) {
       newTab = true;
-      tab = { noteId };
-    }
-
-    if (tab.noteContent == null) {
-      tab.noteContent = (await window.ipc("notes.loadContent", noteId)) ?? "";
+      console.log("OPEN TAB LOGIC IS BROKEN. PLEASE FIX!");
+      throw new Error();
+      tab = { note: null! };
     }
 
     tab.lastActive = new Date();

--- a/src/renderer/components/EditorTabs.tsx
+++ b/src/renderer/components/EditorTabs.tsx
@@ -378,7 +378,7 @@ const StyledDelete = styled(Icon)`
 `;
 
 export const openTab: Listener<"editor.openTab"> = async (ev, ctx) => {
-  const { sidebar, editor } = ctx.getState();
+  const { sidebar, editor, notes } = ctx.getState();
 
   let noteIds: string[];
   let activeTabNoteId;
@@ -412,9 +412,8 @@ export const openTab: Listener<"editor.openTab"> = async (ev, ctx) => {
 
     if (tab == null) {
       newTab = true;
-      console.log("OPEN TAB LOGIC IS BROKEN. PLEASE FIX!");
-      throw new Error();
-      tab = { note: null! };
+      const note = getNoteById(notes, noteId);
+      tab = { note };
     }
 
     tab.lastActive = new Date();

--- a/src/renderer/components/Monaco.tsx
+++ b/src/renderer/components/Monaco.tsx
@@ -139,16 +139,16 @@ export function Monaco(props: MonacoProps): JSX.Element {
 
     // Cache off old state so we can restore it when tab is opened later on.
     if (lastActiveTabNoteId != null) {
-      const oldTab = editor.tabs.find(t => t.noteId === activeNoteId.current);
+      const oldTab = editor.tabs.find(t => t.note.id === activeNoteId.current);
 
       // If old tab wasn't found, it means the tab was closed and we shouldn't
       // bother saving off view state / model.
       if (oldTab != null) {
         const viewState = monacoEditor.current.saveViewState();
-        viewStatesCache[oldTab.noteId] = viewState;
+        viewStatesCache[oldTab.note.id] = viewState;
 
         const model = monacoEditor.current.getModel();
-        modelsCache[oldTab.noteId] = model;
+        modelsCache[oldTab.note.id] = model;
       } else {
         modelsCache[lastActiveTabNoteId] = null;
         viewStatesCache[lastActiveTabNoteId] = null;
@@ -157,26 +157,28 @@ export function Monaco(props: MonacoProps): JSX.Element {
 
     // Load new tab
     if (editor.activeTabNoteId != null) {
-      const newTab = editor.tabs.find(t => t.noteId === editor.activeTabNoteId);
+      const newTab = editor.tabs.find(
+        t => t.note.id === editor.activeTabNoteId,
+      );
       if (newTab == null) {
         throw new Error(`Active tab ${editor.activeTabNoteId} was not found.`);
       }
 
-      let model = modelsCache[newTab.noteId];
+      let model = modelsCache[newTab.note.id];
 
       // First load, gotta create the model.
       if (model == null) {
-        model = monaco.editor.createModel(newTab.noteContent ?? "");
+        model = monaco.editor.createModel(newTab.note.content ?? "");
       }
 
       monacoEditor.current.setModel(model);
-      if (viewStatesCache[newTab.noteId] != null) {
+      if (viewStatesCache[newTab.note.id] != null) {
         monacoEditor.current.restoreViewState(
-          viewStates.current[newTab.noteId]!,
+          viewStates.current[newTab.note.id]!,
         );
       }
 
-      activeNoteId.current = newTab.noteId;
+      activeNoteId.current = newTab.note.id;
     }
   }, [editor.activeTabNoteId, editor.tabs]);
 

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -643,6 +643,7 @@ export const dragNote: Listener<"sidebar.dragNote"> = async (
       note.parent = p.id;
     } else {
       notes.push(note);
+      note.parent = undefined;
     }
 
     return notes;

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -425,11 +425,7 @@ export const createNote: Listener<"sidebar.createNote"> = async (
   const [name, action] = await input.completed;
   if (action === "confirm") {
     try {
-      const note = await window.ipc(
-        "notes.create",
-        name,
-        parentId ?? undefined,
-      );
+      const note = await window.ipc("notes.create", { name, parentId });
 
       ctx.setNotes(notes => {
         if (parentId == null) {

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -214,7 +214,7 @@ export function applySearchString(
 
   const flatNotes = flatten(notes);
   const matches = searchFuzzy(searchString!, flatNotes, {
-    keySelector: n => n.name,
+    keySelector: n => [n.name, n.content],
   });
 
   return matches;

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -452,7 +452,7 @@ export const createNote: Listener<"sidebar.createNote"> = async (
           isEditing: true,
           activeTabNoteId: note.id,
           // Keep in sync with openTab in EditorTabs.tsx
-          tabs: [...prev.editor.tabs, { noteId: note.id, content: "" }],
+          tabs: [...prev.editor.tabs, { note, content: "" }],
         },
       }));
     } catch (e) {

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -495,25 +495,13 @@ export const renameNote: Listener<"sidebar.renameNote"> = async (
   const [name, action] = await input.completed;
   if (action === "confirm") {
     try {
-      const updatedNote = await window.ipc("notes.updateMetadata", id, {
-        name,
-      });
+      await window.ipc("notes.update", id, { name });
 
       ctx.setNotes(notes => {
-        if (updatedNote.parent == null) {
-          const index = notes.findIndex(n => n.id === id);
-          notes.splice(index, 1, updatedNote);
-          return notes;
-        } else {
-          const parent = getNoteById(notes, updatedNote.parent);
-          const index = parent.children!.findIndex(n => n.id === id);
-          if (index === -1) {
-            throw new Error(`Could not find child note with id ${id}`);
-          }
+        const note = getNoteById(notes, id);
+        note.name = name;
 
-          parent.children!.splice(index, 1, updatedNote);
-          return notes;
-        }
+        return notes;
       });
     } catch (e) {
       promptError((e as Error).message);
@@ -612,7 +600,7 @@ export const dragNote: Listener<"sidebar.dragNote"> = async (
 
   const { notes, sidebar } = ctx.getState();
   const note = getNoteById(notes, value.note);
-  let newParent;
+  let newParent: Note | undefined;
   if (value.newParent != null) {
     newParent = getNoteById(notes, value.newParent);
   }
@@ -636,7 +624,7 @@ export const dragNote: Listener<"sidebar.dragNote"> = async (
     }
   }
 
-  const updatedNote = await window.ipc("notes.updateMetadata", note.id, {
+  await window.ipc("notes.update", note.id, {
     parent: newParent?.id,
   });
 
@@ -652,13 +640,13 @@ export const dragNote: Listener<"sidebar.dragNote"> = async (
     }
 
     // Add to new parent (if applicable)
-    if (updatedNote.parent != null) {
-      const newParent = getNoteById(notes, updatedNote.parent);
-      newParent.children ??= [];
-      newParent.children.push(updatedNote);
-      updatedNote.parent = newParent.id;
+    if (newParent != null) {
+      const p = getNoteById(notes, newParent.id);
+      p.children ??= [];
+      p.children.push(note);
+      note.parent = p.id;
     } else {
-      notes.push(updatedNote);
+      notes.push(note);
     }
 
     return notes;
@@ -701,20 +689,22 @@ export const collapseAll: Listener<"sidebar.collapseAll"> = async (_, ctx) => {
 };
 
 export const setNoteSort: Listener<"sidebar.setNoteSort"> = async (ev, ctx) => {
+  const sort = ev.value?.sort ?? DEFAULT_NOTE_SORTING_ALGORITHM;
+
   if (ev.value?.note == null) {
     ctx.setUI({
       sidebar: {
-        sort: ev.value?.sort ?? DEFAULT_NOTE_SORTING_ALGORITHM,
+        sort,
       },
     });
   } else {
-    const note = await window.ipc("notes.updateMetadata", ev.value.note, {
-      sort: ev.value.sort,
+    await window.ipc("notes.update", ev.value.note, {
+      sort,
     });
 
     ctx.setNotes(notes => {
-      const n = getNoteById(notes, note.id);
-      n.sort = note.sort;
+      const n = getNoteById(notes, ev.value!.note!);
+      n.sort = sort;
       return [...notes];
     });
   }

--- a/src/renderer/components/shared/Resizable.tsx
+++ b/src/renderer/components/shared/Resizable.tsx
@@ -2,9 +2,8 @@
 import { stripUnit } from "polished";
 import React, { PropsWithChildren, useRef, useState } from "react";
 import styled from "styled-components";
+import { PX_REGEX } from "../../../shared/domain";
 import { useMouseDrag } from "../../io/mouse";
-
-const PX_REGEX = /^\d+px$/;
 
 export interface ResizableProps {
   className?: string;
@@ -20,7 +19,7 @@ export interface ResizableState {
 }
 
 export function Resizable(
-  props: PropsWithChildren<ResizableProps>
+  props: PropsWithChildren<ResizableProps>,
 ): JSX.Element {
   if (props.width != null && !PX_REGEX.test(props.width)) {
     throw Error("Invalid width format. Expected pixels");
@@ -31,7 +30,7 @@ export function Resizable(
 
   useMouseDrag(
     handle,
-    (drag) => {
+    drag => {
       if (drag != null) {
         switch (drag.state) {
           case "dragging":
@@ -57,7 +56,7 @@ export function Resizable(
         }
       }
     },
-    { cursor: "ew-resize" }
+    { cursor: "ew-resize" },
   );
 
   // Prob not the best solution. Styled Components doesn't work good here

--- a/src/renderer/io/mouse.ts
+++ b/src/renderer/io/mouse.ts
@@ -40,7 +40,7 @@ export type Cursor =
   | "se-resize"
   | "sw-resize"
   | "ew-resize"
-  | "ns-resie"
+  | "ns-resize"
   | "nesw-resize"
   | "nwse-resize"
   | "zoom-in"
@@ -48,7 +48,7 @@ export type Cursor =
 
 export async function cursor(
   cursorIcon: Cursor,
-  cb: () => Promise<void>
+  cb: () => Promise<void>,
 ): Promise<void> {
   const original = document.body.style.cursor;
   document.body.style.cursor = cursorIcon;
@@ -82,7 +82,7 @@ export type DragState =
 export function useMouseDrag(
   ref: RefObject<HTMLElement | Window | null>,
   callback: (drag: MouseDrag | null) => void,
-  opts?: { cursor: Cursor; disabled?: boolean }
+  opts?: { cursor: Cursor; disabled?: boolean },
 ): void {
   const [drag, setDrag] = useState<MouseDrag | null>(null);
 

--- a/src/renderer/logger.ts
+++ b/src/renderer/logger.ts
@@ -11,28 +11,32 @@ export const log: Logger = {
   info: async message => {
     // eslint-disable-next-line no-console
     console.log(message);
-    window.ipc("log.info", message);
+    await window.ipc("log.info", message);
   },
   warn: async message => {
     // eslint-disable-next-line no-console
     console.warn(message);
-    window.ipc("log.warn", message);
+    await window.ipc("log.warn", message);
   },
   error: async (message, err) => {
     // eslint-disable-next-line no-console
     console.error(message);
-    window.ipc("log.error", message);
+    console.error(err);
+    await window.ipc("log.error", message);
+
+    // Easier to do this here, than in main because if we send the error over
+    // IPC the stack will be stripped.
     if (err) {
-      window.ipc("log.error", err.message);
+      await window.ipc("log.error", err.message);
 
       if (err.stack) {
-        window.ipc("log.error", err.stack);
+        await window.ipc("log.error", err.stack);
       }
     }
   },
   debug: async message => {
     // eslint-disable-next-line no-console
     console.log(message);
-    window.ipc("log.debug", message);
+    await window.ipc("log.debug", message);
   },
 };

--- a/src/renderer/preload.ts
+++ b/src/renderer/preload.ts
@@ -4,7 +4,7 @@ import { Ipc, IpcChannel, IPCS, IpcType } from "../shared/ipc";
 
 if (getProcessType() === "main") {
   throw Error(
-    "ipcRenderer is null. Did you accidentally import 'preload.ts' into a main process file?"
+    "ipcRenderer is null. Did you accidentally import 'preload.ts' into a main process file?",
   );
 }
 
@@ -25,11 +25,11 @@ declare global {
     ipc: Ipc;
     addEventListener(
       type: IpcChannel,
-      l: (this: Window, ev: CustomEvent) => void | Promise<void>
+      l: (this: Window, ev: CustomEvent) => void | Promise<void>,
     ): void;
     removeEventListener(
       type: IpcChannel,
-      l: (this: Window, ev: CustomEvent) => void | Promise<void>
+      l: (this: Window, ev: CustomEvent) => void | Promise<void>,
     ): void;
   }
 }
@@ -40,17 +40,9 @@ if (isDevelopment()) {
   console.log("preload complete");
 }
 
-// Dispatch custom event to notify of application menu clicks
-ipcRenderer.on(IpcChannel.ApplicationMenuClick, (_, val: any) => {
-  const ev = new CustomEvent(IpcChannel.ApplicationMenuClick, {
-    detail: val,
+for (const channel of Object.values(IpcChannel)) {
+  ipcRenderer.on(channel, (_, val: unknown) => {
+    const ev = new CustomEvent(channel, { detail: val });
+    window.dispatchEvent(ev);
   });
-  window.dispatchEvent(ev);
-});
-
-ipcRenderer.on(IpcChannel.ContextMenuClick, (_, val: any) => {
-  const ev = new CustomEvent(IpcChannel.ContextMenuClick, {
-    detail: val,
-  });
-  window.dispatchEvent(ev);
-});
+}

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -6,7 +6,7 @@ import { DeepPartial } from "tsdef";
 import { Note } from "../shared/domain/note";
 import { Shortcut } from "../shared/domain/shortcut";
 import { UIEventType, UIEventInput } from "../shared/ui/events";
-import { Section, AppState } from "../shared/ui/app";
+import { Section, AppState, serializeAppState } from "../shared/ui/app";
 import { log } from "./logger";
 
 export interface Store {
@@ -91,16 +91,8 @@ export function useStore(initialState: State): Store {
         ...ui,
       };
 
-      // We need to delete some values before sending them over to the main
-      // thread otherwise electron will throw an error.
       const newUI = pick(newState, "version", "editor", "sidebar", "focused");
-      const clonedUI = cloneDeep(newUI);
-      if (clonedUI?.sidebar != null) {
-        delete clonedUI.sidebar.input;
-        delete clonedUI.sidebar.searchString;
-      }
-
-      void window.ipc("app.saveAppState", clonedUI);
+      void window.ipc("app.saveAppState", serializeAppState(newUI));
       return newState;
     });
   }, []);

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -28,22 +28,22 @@ export type Dispatch = <ET extends UIEventType>(
 
 export type On = <ET extends UIEventType>(
   event: ET | ET[],
-  listener: Listener<ET>
+  listener: Listener<ET>,
 ) => void;
 
 export type Off = <EType extends UIEventType>(
   event: EType | EType[],
-  listener: Listener<EType>
+  listener: Listener<EType>,
 ) => void;
 
 export type Listener<ET extends UIEventType> = (
   ev: { type: ET; value: UIEventInput<ET> | undefined },
-  s: StoreContext
+  s: StoreContext,
 ) => Promise<void> | void;
 
 export type Focus = (
   section: Section[],
-  opts?: { overwrite?: boolean }
+  opts?: { overwrite?: boolean },
 ) => void;
 
 export interface StoreContext {
@@ -56,7 +56,7 @@ export interface StoreContext {
 
 // UI supports partial updates since it's unlikely we'll want to do full updates
 export type SetUI = (
-  t: Transformer<AppState, DeepPartial<AppState>> | DeepPartial<AppState>
+  t: Transformer<AppState, DeepPartial<AppState>> | DeepPartial<AppState>,
 ) => void;
 
 export type SetShortcuts = (t: Transformer<Shortcut[]>) => void;
@@ -78,8 +78,8 @@ export function useStore(initialState: State): Store {
     lastState.current = cloneDeep(state);
   }, [state]);
 
-  const setUI: SetUI = useCallback((transformer) => {
-    setState((prevState) => {
+  const setUI: SetUI = useCallback(transformer => {
+    setState(prevState => {
       const prevUI = pick(prevState, "version", "editor", "sidebar", "focused");
 
       const updates =
@@ -99,11 +99,6 @@ export function useStore(initialState: State): Store {
         delete clonedUI.sidebar.input;
         delete clonedUI.sidebar.searchString;
       }
-      if (clonedUI?.editor != null && clonedUI.editor.tabs != null) {
-        for (const tab of clonedUI.editor.tabs) {
-          tab.noteContent = undefined!;
-        }
-      }
 
       void window.ipc("app.saveAppState", clonedUI);
       return newState;
@@ -115,14 +110,14 @@ export function useStore(initialState: State): Store {
    * data persistence is handled by the main thread.
    */
 
-  const setShortcuts: SetShortcuts = (transformer) => {
-    setState((prevState) => ({
+  const setShortcuts: SetShortcuts = transformer => {
+    setState(prevState => ({
       ...prevState,
       shortcuts: transformer(prevState.shortcuts),
     }));
   };
-  const setNotes: SetNotes = (transformer) => {
-    setState((prevState) => ({
+  const setNotes: SetNotes = transformer => {
+    setState(prevState => ({
       ...prevState,
       notes: transformer(prevState.notes),
     }));
@@ -142,7 +137,7 @@ export function useStore(initialState: State): Store {
         }
       }
 
-      setUI((s) => {
+      setUI(s => {
         // TODO: Clean this up. It's getting messy.
 
         // If only 1 new section move it to top of stack.
@@ -165,7 +160,7 @@ export function useStore(initialState: State): Store {
         }
       });
     },
-    [setUI]
+    [setUI],
   );
 
   const ctx = useMemo(
@@ -176,7 +171,7 @@ export function useStore(initialState: State): Store {
       focus,
       getState: () => lastState.current,
     }),
-    [focus, setUI]
+    [focus, setUI],
   );
 
   const dispatch: Dispatch = useCallback(
@@ -193,12 +188,12 @@ export function useStore(initialState: State): Store {
         await l(ev as any, ctx);
       }
     },
-    [ctx]
+    [ctx],
   ) as Dispatch;
 
   const on: On = <ET extends UIEventType>(
     event: ET | ET[],
-    listener: Listener<ET>
+    listener: Listener<ET>,
   ) => {
     const events = Array.isArray(event) ? event : [event];
     for (const ev of events) {
@@ -213,7 +208,7 @@ export function useStore(initialState: State): Store {
   const off: Off = (event, listener) => {
     const events = Array.isArray(event) ? event : [event];
     for (const ev of events) {
-      const index = listeners.current[ev]!.findIndex((l) => l === listener);
+      const index = listeners.current[ev]!.findIndex(l => l === listener);
       if (index === -1) {
         throw new Error(`No matching listener found on ${ev} for ${listener}`);
       }
@@ -224,7 +219,7 @@ export function useStore(initialState: State): Store {
 
   const store = useMemo(
     () => ({ state, on, off, dispatch }),
-    [dispatch, state]
+    [dispatch, state],
   );
 
   return store;

--- a/src/renderer/utils/prompt.ts
+++ b/src/renderer/utils/prompt.ts
@@ -1,26 +1,40 @@
 import { PromptOptions } from "../../shared/ui/prompt";
+import { log } from "../logger";
 
 const { ipc } = window;
 
-export const promptError = async (errorMessage: string): Promise<void> =>
-  void ipc("app.promptUser", {
+export const promptError = async (errorMessage: string): Promise<void> => {
+  await ipc("app.promptUser", {
     text: errorMessage,
     buttons: [{ text: "Ok", role: "default" }],
     type: "error",
     title: "Error",
   });
+};
 
-export const promptFatal = async (errorMessage: string): Promise<void> =>
-  void ipc("app.promptUser", {
-    text: errorMessage,
-    buttons: [{ text: "Quit", role: "default" }],
+export const promptFatal = async (
+  message: string,
+  err: Error,
+): Promise<void> => {
+  const button = await ipc("app.promptUser", {
+    text: message,
+    detail: err.stack,
+    buttons: [{ text: "Quit", role: "default" }, { text: "Reload" }],
     type: "error",
     title: "Fatal Error",
   });
 
+  if (button.text === "Quit") {
+    await log.info("Shutting down.");
+    await ipc("app.quit");
+  } else if (button.text === "Reload") {
+    await ipc("app.reload");
+  }
+};
+
 export const promptConfirmAction = async (
   verb: string,
-  name: string
+  name: string,
 ): Promise<boolean> => {
   const opts: PromptOptions<boolean> = {
     text: `Are you sure you want to ${verb} ${name}?`,

--- a/src/shared/domain/index.ts
+++ b/src/shared/domain/index.ts
@@ -9,11 +9,13 @@ const ID_LENGTH = 10;
 export const uuid = customAlphabet(ID_ALPHABET, ID_LENGTH);
 export const UUID_REGEX = /[a-zA-Z0-9]{10}$/;
 
-export const UUID_SCHEMA = z.string().refine((val) => UUID_REGEX.test(val));
+export const UUID_SCHEMA = z.string().refine(val => UUID_REGEX.test(val));
 export const DATE_OR_STRING_SCHEMA = z.union([
   z.date(),
-  z.string().transform((v) => parseJSON(v)),
+  z.string().transform(v => parseJSON(v)),
 ]);
+
+export const PX_REGEX = /^\d+px$/;
 
 export interface Resource {
   id: string;

--- a/src/shared/domain/note.ts
+++ b/src/shared/domain/note.ts
@@ -85,8 +85,7 @@ export function sortNotes(notes: Note[], sort: NoteSort): Note[] {
   return r(notes, sort);
 }
 
-export type CreateNoteParams = Partial<Note> & Pick<Note, "name">;
-export function createNote(props: CreateNoteParams): Note {
+export function createNote(props: Partial<Note> & Pick<Note, "name">): Note {
   const note = {
     ...props,
   } as Note;

--- a/src/shared/domain/note.ts
+++ b/src/shared/domain/note.ts
@@ -7,7 +7,7 @@ export interface Note extends Resource {
   version: number;
   name: string;
   parent?: string;
-  children?: Note[];
+  children: Note[];
   sort?: NoteSort;
   content: string;
 }
@@ -85,7 +85,8 @@ export function sortNotes(notes: Note[], sort: NoteSort): Note[] {
   return r(notes, sort);
 }
 
-export function createNote(props: Partial<Note> & { name: string }): Note {
+export type CreateNoteParams = Partial<Note> & Pick<Note, "name">;
+export function createNote(props: CreateNoteParams): Note {
   const note = {
     ...props,
   } as Note;
@@ -96,6 +97,7 @@ export function createNote(props: Partial<Note> & { name: string }): Note {
 
   note.id ??= uuid();
   note.dateCreated ??= new Date();
+  note.content ??= "";
 
   if (!isEmpty(note.children)) {
     for (const child of note.children!) {

--- a/src/shared/domain/note.ts
+++ b/src/shared/domain/note.ts
@@ -1,6 +1,6 @@
 import { Resource, uuid } from ".";
 import { isBlank } from "../utils";
-import { cloneDeep, isEmpty, orderBy } from "lodash";
+import { isEmpty, orderBy } from "lodash";
 import { z } from "zod";
 
 export interface Note extends Resource {
@@ -9,6 +9,7 @@ export interface Note extends Resource {
   parent?: string;
   children?: Note[];
   sort?: NoteSort;
+  content: string;
 }
 
 export enum NoteSort {

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -3,7 +3,7 @@ import { Shortcut } from "./domain/shortcut";
 import { Note, NoteSort } from "./domain/note";
 import { IpcMain, IpcMainInvokeEvent, Point } from "electron";
 import { Menu } from "./ui/menu";
-import { AppState } from "./ui/app";
+import { AppState, SerializedAppState } from "./ui/app";
 
 export const IPCS = [
   "app.setApplicationMenu",
@@ -51,8 +51,8 @@ export interface IpcSchema extends Record<IpcType, (...params: any[]) => any> {
   "app.reload"(): Promise<void>;
   "app.toggleFullScreen"(): Promise<void>;
   "app.quit"(): Promise<void>;
-  "app.loadAppState"(): Promise<AppState>;
-  "app.saveAppState"(ui: AppState): Promise<void>;
+  "app.loadAppState"(): Promise<SerializedAppState>;
+  "app.saveAppState"(ui: SerializedAppState): Promise<void>;
   "app.openInWebBrowser"(url: string): Promise<void>;
   "app.openLogDirectory"(): Promise<void>;
 

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -3,7 +3,7 @@ import { Shortcut } from "./domain/shortcut";
 import { Note, NoteSort } from "./domain/note";
 import { IpcMain, IpcMainInvokeEvent, Point } from "electron";
 import { Menu } from "./ui/menu";
-import { AppState, SerializedAppState } from "./ui/app";
+import { SerializedAppState } from "./ui/app";
 
 export const IPCS = [
   "app.setApplicationMenu",

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -1,6 +1,6 @@
 import { PromptButton, PromptOptions } from "./ui/prompt";
 import { Shortcut } from "./domain/shortcut";
-import { Note } from "./domain/note";
+import { Note, NoteSort } from "./domain/note";
 import { IpcMain, IpcMainInvokeEvent, Point } from "electron";
 import { Menu } from "./ui/menu";
 import { AppState } from "./ui/app";
@@ -23,9 +23,7 @@ export const IPCS = [
 
   "notes.getAll",
   "notes.create",
-  "notes.updateMetadata",
-  "notes.loadContent",
-  "notes.saveContent",
+  "notes.update",
   "notes.delete",
   "notes.moveToTrash",
 
@@ -63,10 +61,8 @@ export interface IpcSchema extends Record<IpcType, (...params: any[]) => any> {
 
   // Notes
   "notes.getAll"(): Promise<Note[]>;
-  "notes.create"(name: string, parent?: string): Promise<Note>;
-  "notes.updateMetadata"(id: string, props: Partial<Note>): Promise<Note>;
-  "notes.loadContent"(id: string): Promise<string | null>;
-  "notes.saveContent"(id: string, content: string): Promise<void>;
+  "notes.create"(params: NoteCreateParams): Promise<Note>;
+  "notes.update"(id: string, params: NoteUpdateParams): Promise<void>;
   "notes.delete"(id: string): Promise<void>;
   "notes.moveToTrash"(id: string): Promise<void>;
 
@@ -81,6 +77,11 @@ export interface IpcSchema extends Record<IpcType, (...params: any[]) => any> {
   "log.warn"(message: string): Promise<void>;
   "log.error"(message: string): Promise<void>;
 }
+
+export type NoteCreateParams = Pick<Note, "name"> & { parent?: Note["id"] };
+export type NoteUpdateParams = Partial<
+  Pick<Note, "name" | "sort" | "parent" | "content">
+>;
 
 export type Ipc = <T extends IpcType, I extends Parameters<IpcSchema[T]>>(
   type: T,

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -75,7 +75,7 @@ export interface IpcSchema extends Record<IpcType, (...params: any[]) => any> {
   "log.info"(message: string): Promise<void>;
   "log.debug"(message: string): Promise<void>;
   "log.warn"(message: string): Promise<void>;
-  "log.error"(message: string): Promise<void>;
+  "log.error"(message: string, err?: Error): Promise<void>;
 }
 
 export type NoteCreateParams = Pick<Note, "name"> & { parent?: Note["id"] };

--- a/src/shared/ui/app.ts
+++ b/src/shared/ui/app.ts
@@ -39,8 +39,7 @@ export interface Editor {
 }
 
 export interface EditorTab {
-  noteId: string;
-  noteContent?: string;
+  note: Note;
   lastActive?: Date;
 }
 
@@ -73,7 +72,7 @@ export function filterOutStaleNoteIds(
 
   if (clonedUI.editor.tabs != null) {
     clonedUI.editor.tabs = clonedUI.editor.tabs.filter(
-      t => currentNoteIds[t.noteId] != null,
+      t => currentNoteIds[t.note.id] != null,
     );
   }
 

--- a/src/shared/ui/app.ts
+++ b/src/shared/ui/app.ts
@@ -85,3 +85,40 @@ export function filterOutStaleNoteIds(
 
   return clonedUI;
 }
+
+export type SerializedAppState = Pick<AppState, "version" | "focused"> & {
+  sidebar: SerializedSidebar;
+  editor: SerializedEditor;
+};
+
+export type SerializedSidebar = Omit<Sidebar, "input">;
+
+export type SerializedEditor = Omit<Editor, "tabs"> & {
+  tabs: SerializedEditorTab[];
+};
+
+export interface SerializedEditorTab {
+  noteId: string;
+  lastActive?: Date;
+}
+
+export function serializeAppState(appState: AppState): SerializedAppState {
+  const { editor, ...cloned } = cloneDeep(appState);
+
+  // We need to delete some values before sending them over to the main
+  // thread otherwise electron will throw an error.
+  if (cloned.sidebar != null) {
+    delete cloned.sidebar.input;
+  }
+
+  return {
+    ...cloned,
+    editor: {
+      ...editor,
+      tabs: editor.tabs.map(t => ({
+        noteId: t.note.id,
+        lastActive: t.lastActive,
+      })),
+    },
+  };
+}

--- a/src/shared/ui/prompt.ts
+++ b/src/shared/ui/prompt.ts
@@ -12,9 +12,10 @@ export interface PromptOptions<T> {
   title?: string;
   type?: PromptType;
   text: string;
+  detail?: string;
   buttons: PromptButton<T>[];
 }
 
 export type PromptUser<T> = (
-  opts: PromptOptions<T>
+  opts: PromptOptions<T>,
 ) => Promise<PromptButton<T>>;

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -3,7 +3,7 @@ export function isBlank(str?: string): boolean {
 }
 
 export function sleep(milliseconds: number): Promise<void> {
-  return new Promise((res) => {
+  return new Promise(res => {
     setTimeout(res, milliseconds);
   });
 }

--- a/test/__factories__/editor.ts
+++ b/test/__factories__/editor.ts
@@ -1,10 +1,10 @@
 import { uuid } from "../../src/shared/domain";
+import { createNote } from "../../src/shared/domain/note";
 import { EditorTab } from "../../src/shared/ui/app";
 
 export function createTab(partial: Partial<EditorTab>): EditorTab {
   return {
     lastActive: partial.lastActive ?? new Date(),
-    noteContent: partial.noteContent ?? "",
-    noteId: partial.noteId ?? uuid(),
+    note: partial.note ?? createNote({ name: uuid() }),
   };
 }

--- a/test/__factories__/ipc.ts
+++ b/test/__factories__/ipc.ts
@@ -13,7 +13,7 @@ export class MockedIpcMainTS implements IpcMainTS {
     handler: (
       event: IpcMainInvokeEvent,
       ...params: Parameters<IpcSchema[Type]>
-    ) => ReturnType<IpcSchema[Type]>
+    ) => ReturnType<IpcSchema[Type]>,
   ): void {
     this.handlers[type] = handler;
   }
@@ -35,7 +35,13 @@ export class MockedIpcMainTS implements IpcMainTS {
   }
 
   async trigger(event: IpcEvent): Promise<void> {
-    await Promise.all(this._listeners[event].map((l) => l()));
+    const eventListeners = this._listeners[event] ?? [];
+
+    if (eventListeners.length === 0) {
+      throw new Error(`No event listeners for ${event}.`);
+    }
+
+    await Promise.all(eventListeners.map(l => l()));
   }
 
   listeners(eventName: string | symbol): Function[] {

--- a/test/__factories__/state.ts
+++ b/test/__factories__/state.ts
@@ -1,24 +1,32 @@
 import { DeepPartial } from "tsdef";
 import { State } from "../../src/renderer/store";
 import { DEFAULT_NOTE_SORTING_ALGORITHM } from "../../src/shared/domain/note";
+import { getLatestSchemaVersion } from "../../src/main/schemas/utils";
+import { APP_STATE_SCHEMAS } from "../../src/main/schemas/appState";
+import { cloneDeep } from "lodash";
 
+const latestVersion = getLatestSchemaVersion(APP_STATE_SCHEMAS);
+
+// TODO: Fix this so we can pass editor: { } and it'll still default tabs to []
 export function createState(partial?: DeepPartial<State>): State {
-  const defaults: State = {
-    notes: [],
-    shortcuts: [],
-    focused: [],
-    sidebar: {
-      scroll: 0,
-      width: "300px",
-      sort: DEFAULT_NOTE_SORTING_ALGORITHM,
-    },
-    editor: {
-      isEditing: false,
-      scroll: 0,
-      tabs: [],
-      tabsScroll: 0,
-    },
-  };
+  const cloned = cloneDeep(partial ?? {});
+  cloned.version ??= latestVersion;
 
-  return Object.assign(defaults, partial);
+  cloned.focused ??= [];
+
+  cloned.sidebar ??= {};
+  cloned.sidebar.scroll ??= 0;
+  cloned.sidebar.width ??= "300px";
+  cloned.sidebar.sort ??= DEFAULT_NOTE_SORTING_ALGORITHM;
+
+  cloned.editor ??= {};
+  cloned.editor.isEditing ??= false;
+  cloned.editor.scroll ??= 0;
+  cloned.editor.tabs ??= [];
+  cloned.editor.tabsScroll ??= 0;
+
+  cloned.shortcuts ??= [];
+  cloned.notes ??= [];
+
+  return cloned as State;
 }

--- a/test/main/notes.spec.ts
+++ b/test/main/notes.spec.ts
@@ -21,7 +21,6 @@ import mockFS from "mock-fs";
 import { omit } from "lodash";
 import {
   createNote,
-  CreateNoteParams,
   getNoteById,
   NoteSort,
 } from "../../src/shared/domain/note";
@@ -37,15 +36,14 @@ afterAll(() => {
   mockFS.restore();
 });
 
+const latestVersion = getLatestSchemaVersion(NOTE_SCHEMAS);
+
 function createMetadata(props?: Partial<NoteMetadata>): NoteMetadata {
   props ??= {};
   props.name ??= `test-note-${uuid()}`;
-  props.version ??= getLatestSchemaVersion(NOTE_SCHEMAS);
+  props.version ??= latestVersion;
 
-  const metadata: NoteMetadata = omit(
-    createNote(props as CreateNoteParams),
-    "children",
-  );
+  const metadata: NoteMetadata = omit(createNote(props as any), "children");
   return metadata;
 }
 

--- a/test/renderer/components/EditorTabs.spec.tsx
+++ b/test/renderer/components/EditorTabs.spec.tsx
@@ -54,7 +54,7 @@ test("openTab opens tabs passed", async () => {
   // Test it sets last tab passed as active
   let { editor } = store.current.state;
   expect(editor.activeTabNoteId).toBe("1");
-  expect(editor.tabs[0]!.noteId).toBe("1");
+  expect(editor.tabs[0]!.note.id).toBe("1");
   expect(editor.tabs[0]!.lastActive).not.toBe(null);
   expect(editor.activeTabNoteId).toBe("1");
 
@@ -69,28 +69,27 @@ test("openTab opens tabs passed", async () => {
 });
 
 test("closeTab closes active tab by default", async () => {
+  const notes = [
+    createNote({ id: "1", name: "foo" }),
+    createNote({ id: "2", name: "bar" }),
+    createNote({ id: "3", name: "baz" }),
+  ];
+
   const store = createStore({
-    notes: [
-      createNote({ id: "1", name: "foo" }),
-      createNote({ id: "2", name: "bar" }),
-      createNote({ id: "3", name: "baz" }),
-    ],
+    notes,
     editor: {
       activeTabNoteId: "1",
       tabs: [
         createTab({
-          noteId: "1",
-          noteContent: "",
+          note: notes[0],
           lastActive: subHours(new Date(), 1),
         }),
         createTab({
-          noteId: "2",
-          noteContent: "",
+          note: notes[1],
           lastActive: subHours(new Date(), 2),
         }),
         createTab({
-          noteId: "3",
-          noteContent: "",
+          note: notes[2],
           lastActive: subHours(new Date(), 3),
         }),
       ],
@@ -108,14 +107,14 @@ test("closeTab closes active tab by default", async () => {
 });
 
 test("closeTab clears out active tab", async () => {
+  const notes = [createNote({ id: "1", name: "foo" })];
   const store = createStore({
-    notes: [createNote({ id: "1", name: "foo" })],
+    notes,
     editor: {
       activeTabNoteId: "1",
       tabs: [
         createTab({
-          noteId: "1",
-          noteContent: "",
+          note: notes[0],
           lastActive: subHours(new Date(), 1),
         }),
       ],
@@ -134,28 +133,26 @@ test("closeTab clears out active tab", async () => {
 });
 
 test("closeTab closes tab passed", async () => {
+  const notes = [
+    createNote({ id: "1", name: "foo" }),
+    createNote({ id: "2", name: "bar" }),
+    createNote({ id: "3", name: "baz" }),
+  ];
   const store = createStore({
-    notes: [
-      createNote({ id: "1", name: "foo" }),
-      createNote({ id: "2", name: "bar" }),
-      createNote({ id: "3", name: "baz" }),
-    ],
+    notes,
     editor: {
       activeTabNoteId: "1",
       tabs: [
         createTab({
-          noteId: "1",
-          noteContent: "",
+          note: notes[0],
           lastActive: subHours(new Date(), 1),
         }),
         createTab({
-          noteId: "2",
-          noteContent: "",
+          note: notes[1],
           lastActive: subHours(new Date(), 2),
         }),
         createTab({
-          noteId: "3",
-          noteContent: "",
+          note: notes[2],
           lastActive: subHours(new Date(), 3),
         }),
       ],
@@ -173,28 +170,26 @@ test("closeTab closes tab passed", async () => {
 });
 
 test("editor.closeAllTabs", async () => {
+  const notes = [
+    createNote({ id: "1", name: "foo" }),
+    createNote({ id: "2", name: "bar" }),
+    createNote({ id: "3", name: "baz" }),
+  ];
   const store = createStore({
-    notes: [
-      createNote({ id: "1", name: "foo" }),
-      createNote({ id: "2", name: "bar" }),
-      createNote({ id: "3", name: "baz" }),
-    ],
+    notes,
     editor: {
       activeTabNoteId: "1",
       tabs: [
         createTab({
-          noteId: "1",
-          noteContent: "",
+          note: notes[0],
           lastActive: subHours(new Date(), 1),
         }),
         createTab({
-          noteId: "2",
-          noteContent: "",
+          note: notes[1],
           lastActive: subHours(new Date(), 2),
         }),
         createTab({
-          noteId: "3",
-          noteContent: "",
+          note: notes[2],
           lastActive: subHours(new Date(), 3),
         }),
       ],
@@ -213,28 +208,26 @@ test("editor.closeAllTabs", async () => {
 });
 
 test("editor.closeOtherTabs", async () => {
+  const notes = [
+    createNote({ id: "1", name: "foo" }),
+    createNote({ id: "2", name: "bar" }),
+    createNote({ id: "3", name: "baz" }),
+  ];
   const store = createStore({
-    notes: [
-      createNote({ id: "1", name: "foo" }),
-      createNote({ id: "2", name: "bar" }),
-      createNote({ id: "3", name: "baz" }),
-    ],
+    notes,
     editor: {
       activeTabNoteId: "1",
       tabs: [
         createTab({
-          noteId: "1",
-          noteContent: "",
+          note: notes[0],
           lastActive: subHours(new Date(), 1),
         }),
         createTab({
-          noteId: "2",
-          noteContent: "",
+          note: notes[1],
           lastActive: subHours(new Date(), 2),
         }),
         createTab({
-          noteId: "3",
-          noteContent: "",
+          note: notes[2],
           lastActive: subHours(new Date(), 3),
         }),
       ],
@@ -243,7 +236,7 @@ test("editor.closeOtherTabs", async () => {
 
   render(<EditorTabs store={store.current} />);
   await act(async () => {
-    // Default behavior is to close active tab
+    // Default behavior is to close non active tab
     store.current.dispatch("editor.closeOtherTabs", undefined!);
   });
 
@@ -251,29 +244,28 @@ test("editor.closeOtherTabs", async () => {
   expect(editor.activeTabNoteId).toBe("1");
   expect(editor.tabs.length).toBe(1);
 });
+
 test("editor.closeTabsToRight", async () => {
+  const notes = [
+    createNote({ id: "1", name: "foo" }),
+    createNote({ id: "2", name: "bar" }),
+    createNote({ id: "3", name: "baz" }),
+  ];
   const store = createStore({
-    notes: [
-      createNote({ id: "1", name: "foo" }),
-      createNote({ id: "2", name: "bar" }),
-      createNote({ id: "3", name: "baz" }),
-    ],
+    notes,
     editor: {
-      activeTabNoteId: "2",
+      activeTabNoteId: "1",
       tabs: [
         createTab({
-          noteId: "1",
-          noteContent: "",
+          note: notes[0],
           lastActive: subHours(new Date(), 1),
         }),
         createTab({
-          noteId: "2",
-          noteContent: "",
+          note: notes[1],
           lastActive: subHours(new Date(), 2),
         }),
         createTab({
-          noteId: "3",
-          noteContent: "",
+          note: notes[2],
           lastActive: subHours(new Date(), 3),
         }),
       ],
@@ -282,40 +274,38 @@ test("editor.closeTabsToRight", async () => {
 
   render(<EditorTabs store={store.current} />);
   await act(async () => {
-    // Default behavior is to close active tab
+    // Default behavior is to close tabs relative to active tab
     store.current.dispatch("editor.closeTabsToRight", undefined!);
   });
 
   const { editor } = store.current.state;
-  expect(editor.activeTabNoteId).toBe("2");
-  expect(editor.tabs.length).toBe(2);
-  expect(editor.tabs[0].noteId).toBe("1");
-  expect(editor.tabs[1].noteId).toBe("2");
+
+  expect(editor.activeTabNoteId).toBe("1");
+  expect(editor.tabs.length).toBe(1);
+  expect(editor.tabs[0].note.id).toBe("1");
 });
 
 test("editor.closeTabsToLeft", async () => {
+  const notes = [
+    createNote({ id: "1", name: "foo" }),
+    createNote({ id: "2", name: "bar" }),
+    createNote({ id: "3", name: "baz" }),
+  ];
   const store = createStore({
-    notes: [
-      createNote({ id: "1", name: "foo" }),
-      createNote({ id: "2", name: "bar" }),
-      createNote({ id: "3", name: "baz" }),
-    ],
+    notes,
     editor: {
       activeTabNoteId: "2",
       tabs: [
         createTab({
-          noteId: "1",
-          noteContent: "",
+          note: notes[0],
           lastActive: subHours(new Date(), 1),
         }),
         createTab({
-          noteId: "2",
-          noteContent: "",
+          note: notes[1],
           lastActive: subHours(new Date(), 2),
         }),
         createTab({
-          noteId: "3",
-          noteContent: "",
+          note: notes[2],
           lastActive: subHours(new Date(), 3),
         }),
       ],
@@ -324,40 +314,38 @@ test("editor.closeTabsToLeft", async () => {
 
   render(<EditorTabs store={store.current} />);
   await act(async () => {
-    // Default behavior is to close active tab
+    // Default behavior is to close tabs to the left of active tab
     store.current.dispatch("editor.closeTabsToLeft", undefined!);
   });
 
   const { editor } = store.current.state;
   expect(editor.activeTabNoteId).toBe("2");
   expect(editor.tabs.length).toBe(2);
-  expect(editor.tabs[0].noteId).toBe("2");
-  expect(editor.tabs[1].noteId).toBe("3");
+  expect(editor.tabs[0].note.id).toBe("2");
+  expect(editor.tabs[1].note.id).toBe("3");
 });
 
 test("nextTab", async () => {
+  const notes = [
+    createNote({ id: "1", name: "foo" }),
+    createNote({ id: "2", name: "bar" }),
+    createNote({ id: "3", name: "baz" }),
+  ];
   const store = createStore({
-    notes: [
-      createNote({ id: "1", name: "foo" }),
-      createNote({ id: "2", name: "bar" }),
-      createNote({ id: "3", name: "baz" }),
-    ],
+    notes,
     editor: {
-      activeTabNoteId: "2",
+      activeTabNoteId: "1",
       tabs: [
         createTab({
-          noteId: "1",
-          noteContent: "",
+          note: notes[0],
           lastActive: subHours(new Date(), 1),
         }),
         createTab({
-          noteId: "2",
-          noteContent: "",
+          note: notes[1],
           lastActive: subHours(new Date(), 2),
         }),
         createTab({
-          noteId: "3",
-          noteContent: "",
+          note: notes[2],
           lastActive: subHours(new Date(), 3),
         }),
       ],
@@ -370,31 +358,29 @@ test("nextTab", async () => {
   });
 
   const { editor } = store.current.state;
-  expect(editor.activeTabNoteId).toBe("3");
+  expect(editor.activeTabNoteId).toBe("2");
 });
 test("previousTab", async () => {
+  const notes = [
+    createNote({ id: "1", name: "foo" }),
+    createNote({ id: "2", name: "bar" }),
+    createNote({ id: "3", name: "baz" }),
+  ];
   const store = createStore({
-    notes: [
-      createNote({ id: "1", name: "foo" }),
-      createNote({ id: "2", name: "bar" }),
-      createNote({ id: "3", name: "baz" }),
-    ],
+    notes,
     editor: {
-      activeTabNoteId: "2",
+      activeTabNoteId: "1",
       tabs: [
         createTab({
-          noteId: "1",
-          noteContent: "",
+          note: notes[0],
           lastActive: subHours(new Date(), 1),
         }),
         createTab({
-          noteId: "2",
-          noteContent: "",
+          note: notes[1],
           lastActive: subHours(new Date(), 2),
         }),
         createTab({
-          noteId: "3",
-          noteContent: "",
+          note: notes[2],
           lastActive: subHours(new Date(), 3),
         }),
       ],
@@ -403,11 +389,11 @@ test("previousTab", async () => {
 
   render(<EditorTabs store={store.current} />);
   await act(async () => {
-    store.current.dispatch("editor.previousTab", undefined!);
+    store.current.dispatch("editor.previousTab");
   });
 
   const { editor } = store.current.state;
-  expect(editor.activeTabNoteId).toBe("1");
+  expect(editor.activeTabNoteId).toBe("3");
 });
 
 test("updateTabsScroll scrolls tabs", async () => {

--- a/test/renderer/components/Sidebar.spec.tsx
+++ b/test/renderer/components/Sidebar.spec.tsx
@@ -39,7 +39,7 @@ test("sidebar.createNote confirm", async () => {
   ((window as any).ipc as jest.Mock).mockReturnValue(
     createNote({
       name: "foo",
-    })
+    }),
   );
 
   // Trigger confirm
@@ -53,7 +53,7 @@ test("sidebar.createNote confirm", async () => {
   expect(note).toEqual(
     expect.objectContaining({
       name: "foo",
-    })
+    }),
   );
   expect(state.focused).toEqual(["editor"]);
   expect(state.sidebar.selected).toEqual([note.id]);
@@ -63,11 +63,10 @@ test("sidebar.createNote confirm", async () => {
       activeTabNoteId: note.id,
       tabs: expect.arrayContaining([
         expect.objectContaining({
-          noteId: note.id,
-          content: "",
+          note,
         }),
       ]),
-    })
+    }),
   );
 });
 
@@ -282,7 +281,7 @@ test("sidebar.dragNote", async () => {
   render(<Sidebar store={store.current} />);
 
   // Notes can't be their own parent.
-  const foo = store.current.state.notes.find((n) => n.name === "foo")!;
+  const foo = store.current.state.notes.find(n => n.name === "foo")!;
   await act(async () => {
     await store.current.dispatch("sidebar.dragNote", {
       note: foo.id,
@@ -292,7 +291,7 @@ test("sidebar.dragNote", async () => {
   expect(foo.parent).toBe(undefined);
 
   // Dont allow infinite loops
-  const bar = store.current.state.notes.find((n) => n.name === "bar")!;
+  const bar = store.current.state.notes.find(n => n.name === "bar")!;
   await act(async () => {
     await store.current.dispatch("sidebar.dragNote", {
       note: bar.id,
@@ -315,7 +314,7 @@ test("sidebar.dragNote", async () => {
     baz.id,
     {
       parent: baz.parent!,
-    }
+    },
   );
 
   // Don't update parent if it's the same (root note)
@@ -331,16 +330,14 @@ test("sidebar.dragNote", async () => {
     foo.id,
     {
       parent: undefined,
-    }
+    },
   );
 
   // Move from root to nested
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  when((window as any).ipc)
-    .calledWith("notes.updateMetadata", "1", {
-      parent: "2",
-    })
-    .mockReturnValueOnce({ ...foo, parent: "2" });
+  when((window as any).ipc).calledWith("notes.updateMetadata", "1", {
+    parent: "2",
+  });
 
   await act(async () => {
     await store.current.dispatch("sidebar.dragNote", {
@@ -352,16 +349,14 @@ test("sidebar.dragNote", async () => {
   expect(updatedFoo.parent).toBe("2");
   expect(bar.children).toContainEqual(expect.objectContaining({ id: "1" }));
   expect(store.current.state.notes).not.toContainEqual(
-    expect.objectContaining({ id: "1" })
+    expect.objectContaining({ id: "1" }),
   );
 
   // Move from nested to root
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  when((window as any).ipc)
-    .calledWith("notes.updateMetadata", "1", {
-      parent: undefined,
-    })
-    .mockReturnValueOnce({ ...updatedFoo, parent: undefined });
+  when((window as any).ipc).calledWith("notes.updateMetadata", "1", {
+    parent: undefined,
+  });
 
   await act(async () => {
     await store.current.dispatch("sidebar.dragNote", {
@@ -373,6 +368,6 @@ test("sidebar.dragNote", async () => {
   expect(updatedFoo2.parent).toBe(undefined);
   expect(bar.children).not.toContainEqual(expect.objectContaining({ id: "1" }));
   expect(store.current.state.notes).toContainEqual(
-    expect.objectContaining({ id: "1" })
+    expect.objectContaining({ id: "1" }),
   );
 });

--- a/test/renderer/components/Sidebar.spec.tsx
+++ b/test/renderer/components/Sidebar.spec.tsx
@@ -1,4 +1,7 @@
-import { Sidebar } from "../../../src/renderer/components/Sidebar";
+import {
+  applySearchString,
+  Sidebar,
+} from "../../../src/renderer/components/Sidebar";
 import { act, fireEvent, render } from "@testing-library/react";
 import React from "react";
 import {
@@ -370,4 +373,31 @@ test("sidebar.dragNote", async () => {
   expect(store.current.state.notes).toContainEqual(
     expect.objectContaining({ id: "1" }),
   );
+});
+
+test("applySearchString", () => {
+  const notes = [
+    createNote({
+      name: "foo",
+      content: "Random string lol",
+    }),
+    createNote({
+      name: "bar",
+      content: "Some more totally random text",
+    }),
+    createNote({
+      name: "baz",
+      content: "qqqqqqqqqqq",
+    }),
+  ];
+
+  // Search by name
+  const matches1 = applySearchString(notes, "f");
+  expect(matches1).toHaveLength(1);
+  expect(matches1[0].name).toBe("foo");
+
+  // Search by content
+  const matches2 = applySearchString(notes, "qqqq");
+  expect(matches2).toHaveLength(1);
+  expect(matches2[0].name).toBe("baz");
 });

--- a/test/renderer/utils/prompt.spec.ts
+++ b/test/renderer/utils/prompt.spec.ts
@@ -1,0 +1,37 @@
+import { promptFatal } from "../../../src/renderer/utils/prompt";
+
+test("promptFatal", async () => {
+  const err = {
+    message: "error-message",
+    stack: "stack",
+  };
+
+  // Quit
+  ((window as any).ipc as jest.Mock).mockResolvedValueOnce({ text: "Quit" });
+  await promptFatal("Something unexpected occurred.", err as Error);
+
+  expect((window as any).ipc).toHaveBeenCalledWith("app.promptUser", {
+    title: "Fatal Error",
+    buttons: [{ text: "Quit", role: "default" }, { text: "Reload" }],
+    text: "Something unexpected occurred.",
+    detail: err.stack,
+    type: "error",
+  });
+
+  expect((window as any).ipc).toHaveBeenCalledWith("app.quit");
+  ((window as any).ipc as jest.Mock).mockReset();
+
+  // Reload
+  ((window as any).ipc as jest.Mock).mockResolvedValueOnce({ text: "Reload" });
+  await promptFatal("Something unexpected occurred.", err as Error);
+
+  expect((window as any).ipc).toHaveBeenCalledWith("app.promptUser", {
+    title: "Fatal Error",
+    buttons: [{ text: "Quit", role: "default" }, { text: "Reload" }],
+    text: "Something unexpected occurred.",
+    detail: err.stack,
+    type: "error",
+  });
+
+  expect((window as any).ipc).toHaveBeenCalledWith("app.reload");
+});

--- a/test/shared/ui/app.spec.ts
+++ b/test/shared/ui/app.spec.ts
@@ -17,10 +17,10 @@ test("filterOutStaleNoteIds", async () => {
     },
     editor: {
       tabs: [
-        { noteId: note1.id },
-        { noteId: note2.id },
-        { noteId: nested1.id },
-        { noteId: "4" },
+        { note: note1 },
+        { note: note2 },
+        { note: nested1 },
+        { note: createNote({ name: "stale-note" }) },
       ],
       activeTabNoteId: note1.id,
     },
@@ -30,7 +30,7 @@ test("filterOutStaleNoteIds", async () => {
   const filteredUI = filterOutStaleNoteIds(ui, [note2]);
   expect(filteredUI.sidebar.expanded).not.toContain(note1.id);
   expect(filteredUI.sidebar.selected).not.toContain(note1.id);
-  expect(filteredUI.editor.tabs).not.toContainEqual({ noteId: note1.id });
-  expect(filteredUI.editor.tabs).toContainEqual({ noteId: nested1.id });
+  expect(filteredUI.editor.tabs).not.toContainEqual({ note: note1 });
+  expect(filteredUI.editor.tabs).toContainEqual({ note: nested1 });
   expect(filteredUI.editor.activeTabNoteId).toBe(undefined);
 });


### PR DESCRIPTION
Notes can now be searched for in the sidebar by their content. Previously notes could only be searched for by name, so this should be a huge improvement.

PR is pretty large in size because it required a major refactor in how we treat tabs. `Note` had to be refactored to include content (previously we treated content separately) and some simplifying was done on the main process with how we manage notes.

To save on complexity there's no longer a cache on the main side. This seems to be overall beneficial because now it's easier to reload notes from the FS whereas before we had no way to bust the cache so changes made to the files externally would only take effect on the next start up.