### PR TITLE
Support attachments with spaces

### DIFF
--- a/src/main/ipcs/notes.ts
+++ b/src/main/ipcs/notes.ts
@@ -228,6 +228,7 @@ export function noteIpcs(
         // Image MIME types always start with "image".
         // https://www.iana.org/assignments/media-types/media-types.xhtml
         type: attachment.mimeType.includes("image") ? "image" : "file",
+        mimeType: attachment.mimeType,
       });
     }
 

--- a/src/main/ipcs/notes.ts
+++ b/src/main/ipcs/notes.ts
@@ -196,15 +196,13 @@ export function noteIpcs(
         continue;
       }
 
-      // Remove spaces from file names since they are URLs and cannot contain spaces.
-      let attachmentName = attachment.name.split(/\s/).join("-");
-
       // Ensure filename is always unique by appending a number to the end of it
       // if we detect the file already exists.
+      const parsedFile = p.parse(attachment.name);
+      const originalName = parsedFile.name;
       let copyNumber = 1;
-      while (fs.existsSync(p.join(noteAttachmentsDirectory, attachmentName))) {
-        const parsedFile = p.parse(attachment.name);
-        attachmentName = `${parsedFile.name}-${copyNumber}${parsedFile.ext}`;
+      while (fs.existsSync(p.join(noteAttachmentsDirectory, attachment.name))) {
+        attachment.name = `${originalName}-${copyNumber}${parsedFile.ext}`;
         copyNumber += 1;
 
         // Prevent infinite loops, and fail softly.
@@ -218,13 +216,13 @@ export function noteIpcs(
 
       await fsp.copyFile(
         attachment.path,
-        p.join(noteAttachmentsDirectory, attachmentName),
+        p.join(noteAttachmentsDirectory, attachment.name),
       );
 
       copiedOverAttachments.push({
-        name: attachmentName,
+        name: attachment.name,
         // Drag-and-drop attachments always go to root directory
-        path: attachmentName,
+        path: attachment.name,
         // Image MIME types always start with "image".
         // https://www.iana.org/assignments/media-types/media-types.xhtml
         type: attachment.mimeType.includes("image") ? "image" : "file",

--- a/src/main/protocols/attachments.ts
+++ b/src/main/protocols/attachments.ts
@@ -46,6 +46,10 @@ export function parseAttachmentPath(
   if (parsedUrl.pathname) {
     filePath = path.join(filePath, parsedUrl.pathname);
   }
+  // Replace URL encoded spaces to normal spaces so we can support files that
+  // contain spaces in their name.
+  // TODO: Replace with replaceAll when we update node.
+  filePath = filePath.split("%20").join(" ");
 
   const attachmentsPath = path.join(
     noteDirectoryPath,

--- a/src/renderer/components/Monaco.tsx
+++ b/src/renderer/components/Monaco.tsx
@@ -119,22 +119,25 @@ export function Monaco(props: MonacoProps): JSX.Element {
           return;
         }
 
-        // If editor is not focused, append content to end of file because there's
-        // no cursor on screen.
+        // When inserting attachments, we should move the content to the next
+        // line if the current line already has content.
         let prefixWithEOL = false;
-        if (store.state.focused[0] !== Section.Editor) {
-          const lineCount = model.getLineCount();
-          monaco.setPosition({ lineNumber: lineCount, column: 1 });
-
-          const isCurrentLineEmpty = model.getLineLength(lineCount) > 0;
-          prefixWithEOL = isCurrentLineEmpty;
+        const cursorPos = monaco.getPosition();
+        if (cursorPos) {
+          const lineLength = model.getLineLength(cursorPos.lineNumber);
+          if (lineLength > 0) {
+            prefixWithEOL = true;
+          }
         }
 
         const eol = model.getEOL();
+        let text = attachments.map(generateAttachmentLink).join(eol);
+        if (prefixWithEOL) {
+          text = eol + text;
+        }
+
         monaco.trigger("keyboard", "type", {
-          text:
-            (prefixWithEOL ? eol : "") +
-            attachments.map(generateAttachmentLink).join(eol),
+          text,
         });
       }
     },

--- a/src/shared/domain/protocols.ts
+++ b/src/shared/domain/protocols.ts
@@ -15,7 +15,8 @@ export interface FileInfo {
 }
 
 export interface Attachment {
-  type: "image" | "file";
+  type: "file" | "image";
+  mimeType: string;
   path: string;
   name: string;
 }

--- a/test/main/ipcs/notes.spec.ts
+++ b/test/main/ipcs/notes.spec.ts
@@ -454,6 +454,7 @@ test("notes.importAttachments", async () => {
     path: "foo.jpg",
     name: "foo.jpg",
     type: "image",
+    mimeType: "image/jpeg",
   });
 
   // Copies over files
@@ -468,6 +469,7 @@ test("notes.importAttachments", async () => {
     path: "bar.txt",
     name: "bar.txt",
     type: "file",
+    mimeType: "text/plain",
   });
 
   // Skips directories
@@ -492,6 +494,7 @@ test("notes.importAttachments", async () => {
     path: "foo-1.jpg",
     name: "foo-1.jpg",
     type: "image",
+    mimeType: "image/jpeg",
   });
 
   const copiedImageDup2 = await ipc.invoke("notes.importAttachments", noteId, [
@@ -505,6 +508,7 @@ test("notes.importAttachments", async () => {
     path: "foo-2.jpg",
     name: "foo-2.jpg",
     type: "image",
+    mimeType: "image/jpeg",
   });
 
   // Replaces spaces with hyphens.
@@ -519,6 +523,7 @@ test("notes.importAttachments", async () => {
     path: "has-spaces-in-name.jpg",
     name: "has-spaces-in-name.jpg",
     type: "image",
+    mimeType: "image/jpeg",
   });
 });
 

--- a/test/main/ipcs/notes.spec.ts
+++ b/test/main/ipcs/notes.spec.ts
@@ -510,21 +510,6 @@ test("notes.importAttachments", async () => {
     type: "image",
     mimeType: "image/jpeg",
   });
-
-  // Replaces spaces with hyphens.
-  const imageWithSpaces = await ipc.invoke("notes.importAttachments", noteId, [
-    {
-      path: path.join("random-dir", "has spaces in name.jpg"),
-      mimeType: "image/jpeg",
-      name: "has spaces in name.jpg",
-    },
-  ]);
-  expect(imageWithSpaces[0]).toEqual({
-    path: "has-spaces-in-name.jpg",
-    name: "has-spaces-in-name.jpg",
-    type: "image",
-    mimeType: "image/jpeg",
-  });
 });
 
 test("loadNotes empty", async () => {


### PR DESCRIPTION
Ideally file names wouldn't have spaces because we treat them as URLs but this at least provides a workaround.

Files with spaces can be added if the user URL encodes them. Ex: `![](attachments://foo bar.jpg` won't work, but `![](attachments://foo%20bar.jpg)` would.

Down the road we'll want to explore an easier option for users such as custom directives, or shortcodes but those will require significant changes so this feels like the best route for now.

It also sets the stage for linking between notes that may have spaces in their names.