### PR TITLE
Add support for linking between notes

### DIFF
--- a/src/main/protocols/attachments.ts
+++ b/src/main/protocols/attachments.ts
@@ -1,8 +1,5 @@
 import { protocol } from "electron";
-import {
-  ATTACHMENTS_PROTOCOL_REGEX,
-  Protocol,
-} from "../../shared/domain/protocols";
+import { isProtocolUrl, Protocol } from "../../shared/domain/protocols";
 import path from "path";
 import fs from "fs";
 import { UUID_REGEX } from "../../shared/domain";
@@ -25,17 +22,12 @@ export function parseAttachmentPath(
   noteDirectoryPath: string,
   url: string,
 ): string {
-  if (!ATTACHMENTS_PROTOCOL_REGEX.test(url)) {
-    throw new Error(`URL ${url} doesn't match attachments protocol.`);
+  if (!isProtocolUrl(Protocol.Attachments, url)) {
+    throw new Error(`URL ${url} is not a valid attachments url.`);
   }
 
   const parsedUrl = new URL(url);
   const parsedSearchParams = new URLSearchParams(parsedUrl.search);
-
-  // Parsed protocol includes the ':'
-  if (parsedUrl.protocol !== `${Protocol.Attachments}:`) {
-    throw new Error(`Invalid attachments protocol: ${parsedUrl.protocol}`);
-  }
 
   const noteId = parsedSearchParams.get("noteId");
   if (noteId == null || !UUID_REGEX.test(noteId)) {
@@ -46,10 +38,7 @@ export function parseAttachmentPath(
   if (parsedUrl.pathname) {
     filePath = path.join(filePath, parsedUrl.pathname);
   }
-  // Replace URL encoded spaces to normal spaces so we can support files that
-  // contain spaces in their name.
-  // TODO: Replace with replaceAll when we update node.
-  filePath = filePath.split("%20").join(" ");
+  filePath = decodeURI(filePath);
 
   const attachmentsPath = path.join(
     noteDirectoryPath,

--- a/src/main/protocols/attachments.ts
+++ b/src/main/protocols/attachments.ts
@@ -42,7 +42,7 @@ export function parseAttachmentPath(
     throw new Error(`Invalid note id (${noteId}) in attachment path.`);
   }
 
-  let filePath = parsedUrl.host;
+  let filePath = parsedUrl.hostname;
   if (parsedUrl.pathname) {
     filePath = path.join(filePath, parsedUrl.pathname);
   }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -23,6 +23,7 @@ import { Editor } from "./components/Editor";
 import { h100, HEADER_SIZES, mb2, w100 } from "./css";
 import { Config } from "../shared/domain/config";
 import { log } from "./logger";
+import { arrayify } from "../shared/utils";
 
 const { ipc } = window;
 async function main() {
@@ -232,7 +233,7 @@ export const push: Listener<"focus.push"> = ({ value: next }, ctx) => {
     return;
   }
 
-  const arr = Array.isArray(next) ? next : [next];
+  const arr = arrayify(next);
   ctx.focus(arr);
 };
 

--- a/src/renderer/components/Editor.tsx
+++ b/src/renderer/components/Editor.tsx
@@ -25,6 +25,8 @@ export function Editor(props: EditorProps): JSX.Element {
   // N.B. We cache the model and view state for monaco tabs here in the Editor
   // vs within the Monaco component because the Monaco component gets unmounted
   // when the editor switches to view mode so we'd lose tab states.
+  //
+  // TODO: Move these up to the store?
   const modelAndViewStateCache = useRef<Record<string, ModelAndViewState>>({});
   const updateCache = useCallback(
     (noteId: string, modelAndViewState: ModelAndViewState) => {

--- a/src/renderer/components/Editor.tsx
+++ b/src/renderer/components/Editor.tsx
@@ -33,7 +33,7 @@ export function Editor(props: EditorProps): JSX.Element {
     [],
   );
   const removeCache = useCallback((noteId: string) => {
-    delete modelAndViewStateCache.current[noteId];
+  delete modelAndViewStateCache.current[noteId];
   }, []);
 
   let activeTab;
@@ -54,7 +54,7 @@ export function Editor(props: EditorProps): JSX.Element {
   } else if (activeTab != null) {
     content = (
       <Markdown
-        noteId={activeTab.note.id}
+        store={store}
         content={activeTab.note.content}
         scroll={state.editor.scroll}
         onScroll={newVal => void store.dispatch("editor.updateScroll", newVal)}

--- a/src/renderer/components/Editor.tsx
+++ b/src/renderer/components/Editor.tsx
@@ -33,7 +33,7 @@ export function Editor(props: EditorProps): JSX.Element {
     [],
   );
   const removeCache = useCallback((noteId: string) => {
-  delete modelAndViewStateCache.current[noteId];
+    delete modelAndViewStateCache.current[noteId];
   }, []);
 
   let activeTab;

--- a/src/renderer/components/EditorTabs.tsx
+++ b/src/renderer/components/EditorTabs.tsx
@@ -10,6 +10,7 @@ import { Section } from "../../shared/ui/app";
 import { Scrollable } from "./shared/Scrollable";
 import { Focusable } from "./shared/Focusable";
 import { arrayify } from "../../shared/utils";
+import { isProtocolUrl } from "../../shared/domain/protocols";
 
 export const EDITOR_TAB_ATTRIBUTE = "data-editor-tab";
 export const TABS_HEIGHT = "4.3rem";
@@ -391,7 +392,7 @@ export const openTab: Listener<"editor.openTab"> = async (ev, ctx) => {
   let activeTabNoteId;
 
   for (const note of notesToOpen) {
-    if (note.startsWith("note://")) {
+    if (isProtocolUrl("note", note)) {
       const foundNote = getNoteByPath(notes, note);
       noteIds.push(foundNote.id);
     } else {
@@ -399,11 +400,12 @@ export const openTab: Listener<"editor.openTab"> = async (ev, ctx) => {
     }
   }
 
-  if (ev.value.active) {
-    if (ev.value.active.startsWith("note://")) {
-      activeTabNoteId = getNoteByPath(notes, ev.value.active).id;
+  const { active } = ev.value;
+  if (active) {
+    if (isProtocolUrl("note", active)) {
+      activeTabNoteId = getNoteByPath(notes, active).id;
     } else {
-      activeTabNoteId = ev.value.active;
+      activeTabNoteId = active;
     }
   }
 

--- a/src/renderer/components/EditorTabs.tsx
+++ b/src/renderer/components/EditorTabs.tsx
@@ -400,7 +400,11 @@ export const openTab: Listener<"editor.openTab"> = async (ev, ctx) => {
   }
 
   if (ev.value.active) {
-    activeTabNoteId = ev.value.active;
+    if (ev.value.active.startsWith("note://")) {
+      activeTabNoteId = getNoteByPath(notes, ev.value.active).id;
+    } else {
+      activeTabNoteId = ev.value.active;
+    }
   }
 
   if (noteIds.length === 0) {

--- a/src/renderer/components/Markdown.tsx
+++ b/src/renderer/components/Markdown.tsx
@@ -110,6 +110,7 @@ export function Markdown(props: MarkdownProps): JSX.Element {
             onClick = (ev: MouseEvent) => {
               ev.preventDefault();
 
+              console.log("OPEN NOTE: ", href);
               void store.dispatch("editor.openTab", {
                 note: href!,
                 active: href!,

--- a/src/renderer/components/Markdown.tsx
+++ b/src/renderer/components/Markdown.tsx
@@ -110,7 +110,6 @@ export function Markdown(props: MarkdownProps): JSX.Element {
             onClick = (ev: MouseEvent) => {
               ev.preventDefault();
 
-              console.log("OPEN NOTE: ", href);
               void store.dispatch("editor.openTab", {
                 note: href!,
                 active: href!,

--- a/src/renderer/components/Markdown.tsx
+++ b/src/renderer/components/Markdown.tsx
@@ -45,36 +45,39 @@ export function Markdown(props: MarkdownProps): JSX.Element {
         code: CodeSpan,
         span: Text,
         img: (props: any) => {
+          if (noteId == null) {
+            throw new Error(`Cannot render links without a noteId.`);
+          }
+
           const otherProps = omit(props, "src");
 
           let src;
           let title;
           let height: string | number | undefined = undefined;
           let width: string | number | undefined = undefined;
+          
           if (props.src != null) {
-            // N.B. Not compatible with windows! We'll need to refactor this when
-            // we expand to supporting windows. Windows uses backwards slashes in
-            // paths so file paths will be considered invalid URLs.
-            //
-            // Some options we could explore:
-            // URL encoding the underlying path (hidden from user)
-            // Not use new URL? What about the params we set tho?
-            const parsedSrc = new URL(props.src);
-            const parsedParams = new URLSearchParams(parsedSrc.search);
+            const url = new URL(props.src);
+            const originalParams = new URLSearchParams(url.search);
 
-            if (parsedParams.has("height")) {
-              height = parsedParams.get("height")!;
+            switch (url.protocol) {
+              case `${Protocol.Attachments}:`:
+                url.search = "";
+                url.searchParams.set("noteId", noteId);
+
+                title = url.pathname;
+                src = url.href;
+                break;
+
+              default:
+                break;
             }
-            if (parsedParams.has("width")) {
-              width = parsedParams.get("width")!;
+
+            if (originalParams.has("height")) {
+              height = originalParams.get("height")!;
             }
-
-            if (parsedSrc.protocol == `${Protocol.Attachments}:`) {
-              parsedSrc.search = "";
-              parsedSrc.searchParams.set("noteId", noteId!);
-
-              title = parsedSrc.pathname;
-              src = parsedSrc.href;
+            if (originalParams.has("width")) {
+              width = originalParams.get("width")!;
             }
           }
 

--- a/src/renderer/components/Monaco.tsx
+++ b/src/renderer/components/Monaco.tsx
@@ -286,10 +286,13 @@ const StyledEditor = styled.div`
 `;
 
 export function generateAttachmentLink(attachment: Attachment): string {
+  // We do this to support spaces
+  const urlEncodedPath = encodeURI(attachment.path);
+
   switch (attachment.type) {
     case "file":
-      return `[${attachment.name}](${Protocol.Attachments}://${attachment.path})`;
+      return `[${attachment.name}](${Protocol.Attachments}://${urlEncodedPath})`;
     case "image":
-      return `![](${Protocol.Attachments}://${attachment.path})`;
+      return `![](${Protocol.Attachments}://${urlEncodedPath})`;
   }
 }

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -126,6 +126,7 @@ export function Sidebar(props: SidebarProps): JSX.Element {
     store.on("sidebar.expandAll", expandAll);
     store.on("sidebar.setNoteSort", setNoteSort);
     store.on("sidebar.openNoteAttachments", openNoteAttachments);
+    store.on("sidebar.openSelectedNotes", openSelectedNotes);
 
     return () => {
       store.off("sidebar.resizeWidth", resizeWidth);
@@ -155,6 +156,7 @@ export function Sidebar(props: SidebarProps): JSX.Element {
       store.off("sidebar.expandAll", expandAll);
       store.off("sidebar.setNoteSort", setNoteSort);
       store.off("sidebar.openNoteAttachments", openNoteAttachments);
+      store.off("sidebar.openSelectedNotes", openSelectedNotes);
     };
   }, [itemIds, state.sidebar, store]);
 
@@ -246,7 +248,11 @@ export function renderMenus(
         void store.dispatch("sidebar.toggleItemExpanded", note.id);
       }
       void store.dispatch("sidebar.setSelection", [note.id]);
-      void store.dispatch("editor.openTab", { note: note.id, active: note.id });
+      void store.dispatch("editor.openTab", {
+        note: note.id,
+        active: note.id,
+        focus: true,
+      });
     };
 
     let icon;
@@ -707,6 +713,48 @@ export const setNoteSort: Listener<"sidebar.setNoteSort"> = async (ev, ctx) => {
       return [...notes];
     });
   }
+};
+
+export const openSelectedNotes: Listener<"sidebar.openSelectedNotes"> = async (
+  _,
+  ctx,
+) => {
+  // Keep in sync with editor.openTab listener
+  const { sidebar, editor, notes } = ctx.getState();
+  const { selected } = sidebar;
+
+  if (selected == null || selected.length === 0) {
+    return;
+  }
+
+  const notesToOpen = selected.map(s => getNoteById(notes, s));
+  const tabs = [...editor.tabs];
+
+  for (const note of notesToOpen) {
+    let newTab = false;
+    let tab = editor.tabs.find(t => t.note.id === note.id);
+
+    if (tab == null) {
+      newTab = true;
+      tab = { note };
+    }
+
+    tab.lastActive = new Date();
+
+    if (newTab) {
+      tabs.push(tab);
+    }
+  }
+
+  ctx.setUI({
+    editor: {
+      tabs,
+      // Default active tab to the first one for now.
+      activeTabNoteId: notesToOpen[0].id,
+    },
+  });
+
+  ctx.focus([Section.Editor]);
 };
 
 export const openNoteAttachments: Listener<

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -746,15 +746,17 @@ export const openSelectedNotes: Listener<"sidebar.openSelectedNotes"> = async (
     }
   }
 
+  // We don't set the editor's active note nor focus the editor when a note is
+  // opened from the sidebar because the user may not want to start editing the
+  // note. If we were to do this, it'd make it difficult to delete note via the
+  // delete shortcut because each time they clicked on a note, they'd have to
+  // click back into the editor and then hit delete.
+
   ctx.setUI({
     editor: {
       tabs,
-      // Default active tab to the first one for now.
-      activeTabNoteId: notesToOpen[0].id,
     },
   });
-
-  ctx.focus([Section.Editor]);
 };
 
 export const openNoteAttachments: Listener<

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -8,6 +8,7 @@ import { Shortcut } from "../shared/domain/shortcut";
 import { UIEventType, UIEventInput } from "../shared/ui/events";
 import { Section, AppState, serializeAppState } from "../shared/ui/app";
 import { log } from "./logger";
+import { arrayify } from "../shared/utils";
 
 export interface Store {
   state: State;
@@ -182,7 +183,7 @@ export function useStore(initialState: State): Store {
       event: ET | ET[],
       listener: Listener<ET>,
     ) => {
-      const events = Array.isArray(event) ? event : [event];
+      const events = arrayify(event);
       for (const ev of events) {
         if (listeners.current[ev] == null) {
           listeners.current[ev] = [];
@@ -193,7 +194,7 @@ export function useStore(initialState: State): Store {
     };
 
     const off: Off = (event, listener) => {
-      const events = Array.isArray(event) ? event : [event];
+      const events = arrayify(event);
       for (const ev of events) {
         const index = listeners.current[ev]!.findIndex(l => l === listener);
         if (index === -1) {

--- a/src/shared/domain/note.ts
+++ b/src/shared/domain/note.ts
@@ -102,6 +102,8 @@ export function createNote(props: Partial<Note> & Pick<Note, "name">): Note {
     for (const child of note.children!) {
       child.parent = note.id;
     }
+  } else {
+    note.children = [];
   }
 
   return note;
@@ -147,6 +149,42 @@ export function getNoteById(
   } else {
     return null;
   }
+}
+
+export function getNoteByPath(
+  notes: Note[],
+  path: string,
+  required?: true,
+): Note;
+export function getNoteByPath(
+  notes: Note[],
+  path: string,
+  required: false,
+): Note | null;
+export function getNoteByPath(
+  notes: Note[],
+  path: string,
+  required = true,
+): Note | null {
+  const pathArray = path.replace("note://", "").split("/");
+
+  let currNote: Note | null = null;
+  do {
+    const currPath = pathArray.shift();
+    let currNotesToCheck = notes;
+
+    if (currNote != null && currNote.children.length > 0) {
+      currNotesToCheck = currNote.children;
+    }
+
+    currNote = currNotesToCheck.find(n => n.name === currPath) ?? null;
+  } while (pathArray.length > 0 && currNote != null);
+
+  if (required && currNote == null) {
+    throw new Error(`Note with path ${path} not found.`);
+  }
+
+  return currNote;
 }
 
 /**

--- a/src/shared/domain/protocols.ts
+++ b/src/shared/domain/protocols.ts
@@ -6,10 +6,6 @@ export enum Protocol {
   // main process.
 }
 
-// noteId bit in sync with UUID_REGEX
-export const ATTACHMENTS_PROTOCOL_REGEX =
-  /^attachments:\/\/.+\?noteId=[a-zA-Z0-9]{10}$/;
-
 export interface FileInfo {
   mimeType: string;
   path: string;

--- a/src/shared/domain/protocols.ts
+++ b/src/shared/domain/protocols.ts
@@ -2,6 +2,8 @@
 
 export enum Protocol {
   Attachments = "attachments",
+  // Note links are not a protocol because we don't need to handle them on the
+  // main process.
 }
 
 // noteId bit in sync with UUID_REGEX
@@ -19,4 +21,23 @@ export interface Attachment {
   mimeType: string;
   path: string;
   name: string;
+}
+
+const PROTOCOL_REGEX = /^[a-z0-9]+:\/\//;
+
+export function isProtocolUrl(
+  protocol: string | Protocol,
+  url: string | null,
+): boolean {
+  if (url == null) {
+    return false;
+  }
+
+  const match = url.match(PROTOCOL_REGEX);
+  if (!match) {
+    return false;
+  }
+
+  const matchedString = match[0];
+  return matchedString.includes(protocol);
 }

--- a/src/shared/io/defaultShortcuts.ts
+++ b/src/shared/io/defaultShortcuts.ts
@@ -82,8 +82,8 @@ const shortcuts: Shortcut[] = [
     repeat: true,
   },
   {
-    name: "editor.openTab",
-    event: "editor.openTab",
+    name: "sidebar.openSelectedNotes",
+    event: "sidebar.openSelectedNotes",
     keys: [KeyCode.Enter],
     when: Section.Sidebar,
   },

--- a/src/shared/ui/events.ts
+++ b/src/shared/ui/events.ts
@@ -46,13 +46,16 @@ export interface UIEvents {
   "sidebar.moveSelectionDown": void;
   "sidebar.search": string;
   "sidebar.focusSearch": void;
+  "sidebar.openSelectedNotes": void;
 
   // Editor
   "editor.save": void;
   "editor.toggleView": void;
   "editor.setContent": { noteId: string; content: string };
   "editor.updateScroll": number;
-  "editor.openTab": { note: string | string[]; active?: string } | undefined;
+  "editor.openTab":
+    | { note: string | string[]; active?: string; focus?: boolean }
+    | undefined;
 
   "editor.closeTab": string;
   "editor.closeAllTabs": void;
@@ -115,6 +118,7 @@ export const LIST_OF_EVENTS: (keyof UIEvents)[] = [
   "sidebar.moveSelectionDown",
   "sidebar.search",
   "sidebar.focusSearch",
+  "sidebar.openSelectedNotes",
 
   // Editor
   "editor.save",

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -2,6 +2,7 @@ export function isBlank(str?: string): boolean {
   return str == null || /^\s*$/.test(str);
 }
 
+// Can't use promisify here because we import this in renderer
 export function sleep(milliseconds: number): Promise<void> {
   return new Promise(res => {
     setTimeout(res, milliseconds);
@@ -11,3 +12,7 @@ export function sleep(milliseconds: number): Promise<void> {
 // Source: https://stackoverflow.com/a/37563868
 export const ISO_8601_REGEX =
   /^\d{4}(-\d\d(-\d\d(T\d\d:\d\d(:\d\d)?(\.\d+)?(([+-]\d\d:\d\d)|Z)?)?)?)?/i;
+
+export function arrayify<T>(value: T | T[]): T[] {
+  return Array.isArray(value) ? value : [value];
+}

--- a/test/main/ipcs/notes.spec.ts
+++ b/test/main/ipcs/notes.spec.ts
@@ -141,7 +141,7 @@ test("notes.create", async () => {
     note.id,
   );
 
-  expect(note).toEqual(omit(noteFromFS, "version"));
+  expect(omit(note, "children")).toEqual(omit(noteFromFS, "version"));
 });
 
 test("notes.update", async () => {

--- a/test/main/protocols/attachments.spec.ts
+++ b/test/main/protocols/attachments.spec.ts
@@ -82,6 +82,16 @@ test("parseAttachmentPath", () => {
     ),
   ).toMatch(`notes/${noteId}/${ATTACHMENTS_DIRECTORY}/longer/path/to/bar.jpg`);
 
+  // Decodes URL encoded spaces
+  expect(
+    parseAttachmentPath(
+      "notes",
+      `attachments://longer/path/to/foo%20bar.jpg?noteId=${noteId}`,
+    ),
+  ).toMatch(
+    `notes/${noteId}/${ATTACHMENTS_DIRECTORY}/longer/path/to/foo bar.jpg`,
+  );
+
   // Throw if file was outside of the folder.
   expect(() =>
     parseAttachmentPath(

--- a/test/main/protocols/attachments.spec.ts
+++ b/test/main/protocols/attachments.spec.ts
@@ -37,14 +37,19 @@ test("registerAttachmentsProtocol", async () => {
   const callback = registerFileProtocol.mock.calls[0][1];
   expect(typeof callback).toBe("function");
 
+  // Random string
   expect(() => callback({ url: "not-attachment-url" }, jest.fn())).toThrow(
-    /URL .* doesn't match/,
+    /URL .* is not a valid attachments url/,
   );
+
+  //Missing prefix
   expect(() => callback({ url: "foo.jpg?noteId=123" }, jest.fn())).toThrow(
-    /URL .* doesn't match/,
+    /URL .* is not a valid attachments url/,
   );
+
+  // Missing noteId param
   expect(() => callback({ url: "attachments://foo.jpg" }, jest.fn())).toThrow(
-    /URL .* doesn't match/,
+    /Invalid note id \(.*\) in attachment path/,
   );
 
   const cb = jest.fn();

--- a/test/renderer/components/EditorTabs.spec.tsx
+++ b/test/renderer/components/EditorTabs.spec.tsx
@@ -10,28 +10,12 @@ import { createNote } from "../../../src/shared/domain/note";
 import { createTab } from "../../__factories__/editor";
 import { subHours } from "date-fns";
 
-jest.useFakeTimers();
+beforeAll(() => {
+  jest.useFakeTimers();
+});
 
-test("openTab opens selected note by default", async () => {
-  const store = createStore({
-    notes: [createNote({ id: "1", name: "foo" })],
-    sidebar: {
-      selected: ["1"],
-    },
-    editor: {
-      activeTabNoteId: undefined,
-      tabs: [],
-    },
-  });
-  render(<EditorTabs store={store.current} />);
-
-  await act(async () => {
-    await store.current.dispatch("editor.openTab", undefined);
-  });
-
-  const { editor } = store.current.state;
-  expect(editor.activeTabNoteId).toBe("1");
-  expect(editor.tabs[0]!.lastActive).not.toBe(null);
+afterAll(() => {
+  jest.useRealTimers();
 });
 
 test("openTab opens tabs passed", async () => {
@@ -47,16 +31,14 @@ test("openTab opens tabs passed", async () => {
   });
   render(<EditorTabs store={store.current} />);
 
+  // Open note without setting as active
   await act(async () => {
     await store.current.dispatch("editor.openTab", { note: "1" });
   });
 
-  // Test it sets last tab passed as active
   let { editor } = store.current.state;
-  expect(editor.activeTabNoteId).toBe("1");
   expect(editor.tabs[0]!.note.id).toBe("1");
   expect(editor.tabs[0]!.lastActive).not.toBe(null);
-  expect(editor.activeTabNoteId).toBe("1");
 
   await act(async () => {
     await store.current.dispatch("editor.openTab", {

--- a/test/renderer/components/EditorTabs.spec.tsx
+++ b/test/renderer/components/EditorTabs.spec.tsx
@@ -53,6 +53,48 @@ test("openTab opens tabs passed", async () => {
   expect(editor.tabs).toHaveLength(3);
 });
 
+test("openTab works with note paths too", async () => {
+  const store = createStore({
+    notes: [
+      createNote({ id: "1", name: "foo" }),
+      createNote({ id: "2", name: "bar" }),
+      createNote({
+        id: "3",
+        name: "baz",
+        children: [createNote({ id: "4", name: "Nested" })],
+      }),
+    ],
+    editor: {
+      tabs: [],
+    },
+  });
+  render(<EditorTabs store={store.current} />);
+
+  // Test it can open a note from path
+  await act(async () => {
+    await store.current.dispatch("editor.openTab", {
+      note: "note://foo",
+      active: "note://foo",
+    });
+  });
+
+  let { editor } = store.current.state;
+  expect(editor.tabs[0]!.note.id).toBe("1");
+  expect(editor.activeTabNoteId).toBe("1");
+
+  // Test it can open note from nested path
+  await act(async () => {
+    await store.current.dispatch("editor.openTab", {
+      note: "note://baz/Nested",
+      active: "note://baz/Nested",
+    });
+  });
+
+  ({ editor } = store.current.state);
+  expect(editor.tabs[1]!.note.id).toBe("4");
+  expect(editor.activeTabNoteId).toBe("4");
+});
+
 test("closeTab closes active tab by default", async () => {
   const notes = [
     createNote({ id: "1", name: "foo" }),

--- a/test/renderer/components/Markdown.spec.tsx
+++ b/test/renderer/components/Markdown.spec.tsx
@@ -7,9 +7,10 @@ import { Protocol } from "../../../src/shared/domain/protocols";
 import { createStore } from "../../__factories__/store";
 
 test("Markdown img sets width and height", async () => {
+  const noteId = uuid();
   const store = createStore({
     editor: {
-      activeTabNoteId: uuid(),
+      activeTabNoteId: noteId,
       tabs: [],
     },
   });
@@ -39,7 +40,7 @@ test("Markdown img sets width and height", async () => {
 
   const parsedSrc = new URL(renderedImg.src);
   const parsedParams = new URLSearchParams(parsedSrc.search);
-  expect(parsedParams.has("noteId")).toBe(true);
+  expect(parsedParams.get("noteId")).toBe(noteId);
 
   // Main doesn't need to know these so we unset them in the url.
   expect(parsedParams.has("height")).toBe(false);

--- a/test/renderer/components/Markdown.spec.tsx
+++ b/test/renderer/components/Markdown.spec.tsx
@@ -4,11 +4,18 @@ import { Markdown } from "../../../src/renderer/components/Markdown";
 import { uuid } from "../../../src/shared/domain";
 import { useRemark } from "react-remark";
 import { Protocol } from "../../../src/shared/domain/protocols";
+import { createStore } from "../../__factories__/store";
 
 test("Markdown img sets width and height", async () => {
+  const store = createStore({
+    editor: {
+      activeTabNoteId: uuid(),
+      tabs: [],
+    },
+  });
   render(
     <Markdown
-      noteId={uuid()}
+      store={store.current}
       content="foobar"
       scroll={0}
       onScroll={jest.fn()}
@@ -40,9 +47,15 @@ test("Markdown img sets width and height", async () => {
 });
 
 test("Markdown attachment link", async () => {
+  const store = createStore({
+    editor: {
+      activeTabNoteId: uuid(),
+      tabs: [],
+    },
+  });
   render(
     <Markdown
-      noteId={uuid()}
+      store={store.current}
       content="foobar"
       scroll={0}
       onScroll={jest.fn()}
@@ -75,9 +88,15 @@ test("Markdown attachment link", async () => {
 });
 
 test("Markdown http link", async () => {
+  const store = createStore({
+    editor: {
+      activeTabNoteId: uuid(),
+      tabs: [],
+    },
+  });
   render(
     <Markdown
-      noteId={uuid()}
+      store={store.current}
       content="foobar"
       scroll={0}
       onScroll={jest.fn()}

--- a/test/renderer/components/Monaco.spec.tsx
+++ b/test/renderer/components/Monaco.spec.tsx
@@ -1,5 +1,8 @@
 import React from "react";
-import { Monaco } from "../../../src/renderer/components/Monaco";
+import {
+  generateAttachmentLink,
+  Monaco,
+} from "../../../src/renderer/components/Monaco";
 import { createNote } from "../../../src/shared/domain/note";
 import { createStore } from "../../__factories__/store";
 import { fireEvent, render } from "@testing-library/react";
@@ -7,7 +10,7 @@ import { uuid } from "../../../src/shared/domain";
 import * as monaco from "monaco-editor";
 import { Section } from "../../../src/shared/ui/app";
 import { when } from "jest-when";
-import { sleep } from "../../../src/shared/utils";
+import { Protocol } from "../../../src/shared/domain/protocols";
 
 test("importAttachments", async () => {
   const noteId = uuid();
@@ -88,4 +91,60 @@ test("importAttachments", async () => {
       },
     ],
   );
+});
+
+test("generateAttachmentLink", () => {
+  expect(
+    generateAttachmentLink({
+      name: "foo.txt",
+      path: "foo.txt",
+      mimeType: "text/plain",
+      type: "file",
+    }),
+  ).toBe(`[foo.txt](${Protocol.Attachments}://foo.txt)`);
+
+  expect(
+    generateAttachmentLink({
+      name: "bar.txt",
+      path: "nested/bar.txt",
+      mimeType: "text/plain",
+      type: "file",
+    }),
+  ).toBe(`[bar.txt](${Protocol.Attachments}://nested/bar.txt)`);
+
+  expect(
+    generateAttachmentLink({
+      name: "foo bar.txt",
+      path: "foo bar.txt",
+      mimeType: "text/plain",
+      type: "file",
+    }),
+  ).toBe(`[foo bar.txt](${Protocol.Attachments}://foo%20bar.txt)`);
+
+  expect(
+    generateAttachmentLink({
+      name: "baz.jpg",
+      path: "baz.jpg",
+      mimeType: "image/jpeg",
+      type: "image",
+    }),
+  ).toBe(`![](${Protocol.Attachments}://baz.jpg)`);
+
+  expect(
+    generateAttachmentLink({
+      name: "qux.jpg",
+      path: "nested/qux.jpg",
+      mimeType: "image/jpeg",
+      type: "image",
+    }),
+  ).toBe(`![](${Protocol.Attachments}://nested/qux.jpg)`);
+
+  expect(
+    generateAttachmentLink({
+      name: "two words.jpg",
+      path: "two words.jpg",
+      mimeType: "image/jpeg",
+      type: "image",
+    }),
+  ).toBe(`![](${Protocol.Attachments}://two%20words.jpg)`);
 });

--- a/test/shared/domain/protocols.spec.ts
+++ b/test/shared/domain/protocols.spec.ts
@@ -1,20 +1,14 @@
-import { uuid } from "../../../src/shared/domain";
-import { ATTACHMENTS_PROTOCOL_REGEX } from "../../../src/shared/domain/protocols";
+import { isProtocolUrl } from "../../../src/shared/domain/protocols";
 
-test("ATTACHMENTS_PROTOCOL_REGEX", () => {
-  expect(`attachments://foo?noteId=${uuid()}`).toMatch(
-    ATTACHMENTS_PROTOCOL_REGEX,
-  );
+test("isProtocolUrl", () => {
+  expect(isProtocolUrl("foo", null)).toBe(false);
 
-  expect(`attachments://foo?noteId=nota24sumber`).not.toMatch(
-    ATTACHMENTS_PROTOCOL_REGEX,
-  );
+  // No protocol
+  expect(isProtocolUrl("foo", "lol.txt")).toBe(false);
 
-  expect(`attach://foo?noteId=${uuid()}`).not.toMatch(
-    ATTACHMENTS_PROTOCOL_REGEX,
-  );
+  // Wrong protocol
+  expect(isProtocolUrl("foo", "bar://lol.txt")).toBe(false);
 
-  expect(`foo?noteId=${uuid()}`).not.toMatch(ATTACHMENTS_PROTOCOL_REGEX);
-
-  expect(`attachments://foo`).not.toMatch(ATTACHMENTS_PROTOCOL_REGEX);
+  // Good
+  expect(isProtocolUrl("foo", "foo://lol.txt")).toBe(true);
 });

--- a/test/shared/io/shortcuts.spec.ts
+++ b/test/shared/io/shortcuts.spec.ts
@@ -10,7 +10,13 @@ import { Section } from "../../../src/shared/ui/app";
 import * as Utils from "../../../src/shared/utils";
 import { mockStore } from "../../__mocks__/store";
 
-jest.useFakeTimers();
+beforeAll(() => {
+  jest.useFakeTimers();
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});
 
 const sleep = jest.fn().mockImplementation(() => Promise.resolve({}));
 jest.spyOn(Utils, "sleep").mockImplementation(sleep);
@@ -42,7 +48,7 @@ test.each([undefined, [Section.Sidebar]])(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (focused: any) => {
     expect(shouldExecute(focused)).toBe(true);
-  }
+  },
 );
 test("shouldExecute contextual", () => {
   expect(shouldExecute([Section.Sidebar], Section.Sidebar)).toBe(true);

--- a/test/shared/utils.spec.ts
+++ b/test/shared/utils.spec.ts
@@ -1,0 +1,26 @@
+import { arrayify, isBlank, sleep } from "../../src/shared/utils";
+
+test("isBlank", () => {
+  expect(isBlank(null)).toBe(true);
+  expect(isBlank("")).toBe(true);
+  expect(isBlank(" ")).toBe(true);
+  expect(isBlank("  ")).toBe(true);
+  expect(isBlank("foo")).toBe(false);
+});
+
+test("sleep", async () => {
+  jest.useFakeTimers();
+
+  const prom = sleep(100);
+
+  jest.advanceTimersByTime(150);
+  await expect(prom).resolves.toBe(undefined);
+
+  jest.useRealTimers();
+});
+
+test("arrayify", () => {
+  expect(arrayify(1)).toEqual([1]);
+  expect(arrayify([1])).toEqual([1]);
+  expect(arrayify(["foo", "bar"])).toEqual(["foo", "bar"]);
+});


### PR DESCRIPTION
Notes can now be linked between each other, and some clean up was done on the attachments code to support dragging and dropping images that have spaces in their names into files.

Linking between notes:
![note-links](https://user-images.githubusercontent.com/25796180/205207732-f3fb9a89-18e8-4258-a9e7-a497aecd0300.gif)

Drag and drop images:
![drag-and-drop](https://user-images.githubusercontent.com/25796180/205207749-4cf57f98-9393-405c-9494-b57918f03eb1.gif)
