### PR TITLE
Allow app menu to be toggleable

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -60,14 +60,16 @@ export async function main(): Promise<void> {
         },
       );
 
-      let { windowHeight, windowWidth } = configFile.content;
+      const { windowHeight, windowWidth, autoHideAppMenu } = configFile.content;
+
       mainWindow = new BrowserWindow({
-        height: windowHeight,
-        width: windowWidth,
         // Title must be specified otherwise npm package name will be used until
         // index.html has loaded.
         title: "Marker",
         icon: "static/icon.png",
+        height: windowHeight,
+        width: windowWidth,
+        autoHideMenuBar: autoHideAppMenu,
         webPreferences: {
           preload: MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY,
           // Do not change these. They are for security purposes.
@@ -84,10 +86,7 @@ export async function main(): Promise<void> {
       }
 
       mainWindow.on("resize", async () => {
-        const [width, height] = mainWindow.getSize();
-        windowHeight = height;
-        windowWidth = width;
-
+        const [windowWidth, windowHeight] = mainWindow.getSize();
         await configFile.update({
           windowHeight,
           windowWidth,

--- a/src/main/ipcs/app.ts
+++ b/src/main/ipcs/app.ts
@@ -235,6 +235,8 @@ export function buildMenus(
           registerAccelerator,
         };
 
+        // Checkbox menus always trigger the click handler unlike radio button
+        // menus.
         t.click = buildClickHandler(menu.event, menu.eventInput, channel);
 
         break;

--- a/src/main/ipcs/app.ts
+++ b/src/main/ipcs/app.ts
@@ -150,6 +150,28 @@ export function appIpcs(
       throw new Error(err);
     }
   });
+
+  ipc.handle("app.toggleAutoHideAppMenu", async () => {
+    const bw = BrowserWindow.getFocusedWindow();
+
+    if (bw == null) {
+      return;
+    }
+
+    // Toggling autoHideMenuBar has a delay before changes take effect so we
+    // trigger immediate results by setting menuBarVisible.
+    if (!bw.isMenuBarAutoHide()) {
+      bw.autoHideMenuBar = true;
+      bw.menuBarVisible = false;
+
+      await config.update({ autoHideAppMenu: true });
+    } else {
+      bw.autoHideMenuBar = false;
+      bw.menuBarVisible = true;
+
+      await config.update({ autoHideAppMenu: false });
+    }
+  });
 }
 
 export function buildMenus(
@@ -200,6 +222,20 @@ export function buildMenus(
         if (!menu.checked) {
           t.click = buildClickHandler(menu.event, menu.eventInput, channel);
         }
+
+        break;
+
+      case "checkbox":
+        t = {
+          label: menu.label,
+          type: "checkbox",
+          accelerator: menu.shortcut,
+          enabled: !menu.disabled,
+          checked: menu.checked,
+          registerAccelerator,
+        };
+
+        t.click = buildClickHandler(menu.event, menu.eventInput, channel);
 
         break;
 

--- a/src/main/schemas/config/4_addAutoHideAppMenu.ts
+++ b/src/main/schemas/config/4_addAutoHideAppMenu.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+import { ConfigV3 } from "./3_addDeveloperMode";
+
+export interface ConfigV4 {
+  version: number;
+  windowHeight: number;
+  windowWidth: number;
+  dataDirectory?: string;
+  logDirectory?: string;
+  developerMode?: boolean;
+  autoHideAppMenu?: boolean;
+}
+
+export const configSchemaV4: z.Schema<ConfigV4> = z.preprocess(
+  obj => {
+    const config = obj as ConfigV3 | ConfigV4;
+    if (config.version === 3) {
+      config.version = 4;
+    }
+
+    return config;
+  },
+  z.object({
+    version: z.literal(4),
+    windowHeight: z.number().min(1),
+    windowWidth: z.number().min(1),
+    dataDirectory: z.string().optional(),
+    logDirectory: z.string(),
+    developerMode: z.boolean().optional(),
+    autoHideAppMenu: z.boolean().optional(),
+  }),
+);

--- a/src/main/schemas/config/index.ts
+++ b/src/main/schemas/config/index.ts
@@ -1,9 +1,11 @@
 import { configSchemaV1 } from "./1_initialDefinition";
 import { configSchemaV2 } from "./2_addLogDirectory";
 import { configSchemaV3 } from "./3_addDeveloperMode";
+import { configSchemaV4 } from "./4_addAutoHideAppMenu";
 
 export const CONFIG_SCHEMAS = {
   1: configSchemaV1,
   2: configSchemaV2,
   3: configSchemaV3,
+  4: configSchemaV4,
 };

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -75,6 +75,7 @@ export function App(props: AppProps): JSX.Element {
     store.on("app.openLogDirectory", openLogs);
     store.on("app.openConfig", openConfig);
     store.on("app.openNoteAttachments", openNoteAttachments);
+    store.on("app.toggleAutoHideAppMenu", toggleAutoHideAppMenu);
 
     store.on("sidebar.focusSearch", globalSearch);
 
@@ -107,6 +108,7 @@ export function App(props: AppProps): JSX.Element {
       store.off("app.openLogDirectory", openLogs);
       store.off("app.openConfig", openConfig);
       store.off("app.openNoteAttachments", openNoteAttachments);
+      store.off("app.toggleAutoHideAppMenu", toggleAutoHideAppMenu);
 
       store.off("sidebar.focusSearch", globalSearch);
 
@@ -276,4 +278,10 @@ export const openNoteAttachments: Listener<
   }
 
   await window.ipc("notes.openAttachments", noteId);
+};
+
+export const toggleAutoHideAppMenu: Listener<
+  "app.toggleAutoHideAppMenu"
+> = async () => {
+  await ipc("app.toggleAutoHideAppMenu");
 };

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -446,6 +446,7 @@ export const createNote: Listener<"sidebar.createNote"> = async (
     setSidebarInput(ctx),
   );
 
+  // Auto expand parent if one was passed
   if (
     parentId != null &&
     (sidebar.expanded == null || sidebar.expanded?.every(id => id !== parentId))

--- a/src/renderer/menus/appMenu.ts
+++ b/src/renderer/menus/appMenu.ts
@@ -135,6 +135,13 @@ export function useApplicationMenu(store: Store, config: Config): void {
             shortcut: shortcutLabels["app.toggleSidebar"],
             event: "app.toggleSidebar",
           },
+          {
+            label: "Toggle auto hide app menu",
+            type: "checkbox",
+            checked: config.autoHideAppMenu,
+            shortcut: shortcutLabels["app.toggleAutoHideAppMenu"],
+            event: "app.toggleAutoHideAppMenu",
+          },
         ],
       },
       ...optionals,

--- a/src/renderer/menus/appMenu.ts
+++ b/src/renderer/menus/appMenu.ts
@@ -16,6 +16,7 @@ export function useApplicationMenu(store: Store, config: Config): void {
   );
   const focused = state.focused[0];
   const selected = state.sidebar.selected?.[0];
+  const sidebarHidden = state.sidebar.hidden;
   const { isEditing } = state.editor;
 
   useEffect(() => {
@@ -130,8 +131,9 @@ export function useApplicationMenu(store: Store, config: Config): void {
             event: "app.toggleFullScreen",
           },
           {
-            label: "Toggle sidebar",
-            type: "normal",
+            label: "Toggle sidebar hidden",
+            type: "checkbox",
+            checked: sidebarHidden,
             shortcut: shortcutLabels["app.toggleSidebar"],
             event: "app.toggleSidebar",
           },
@@ -146,7 +148,7 @@ export function useApplicationMenu(store: Store, config: Config): void {
       },
       ...optionals,
     ]);
-  }, [focused, selected, shortcutLabels, isEditing, config]);
+  }, [focused, selected, shortcutLabels, isEditing, config, sidebarHidden]);
 
   useEffect(() => {
     const onClick = async (ev: CustomEvent) => {

--- a/src/shared/domain/config.ts
+++ b/src/shared/domain/config.ts
@@ -5,4 +5,5 @@ export interface Config {
   dataDirectory?: string;
   logDirectory: string;
   developerMode?: boolean;
+  autoHideAppMenu?: boolean;
 }

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -19,6 +19,7 @@ export const IPCS = [
   "app.saveAppState",
   "app.openInWebBrowser",
   "app.openLogDirectory",
+  "app.toggleAutoHideAppMenu",
 
   "shortcuts.getAll",
 
@@ -58,6 +59,7 @@ export interface IpcSchema extends Record<IpcType, (...params: any[]) => any> {
   "app.saveAppState"(ui: SerializedAppState): Promise<void>;
   "app.openInWebBrowser"(url: string): Promise<void>;
   "app.openLogDirectory"(): Promise<void>;
+  "app.toggleAutoHideAppMenu"(): Promise<void>;
 
   // Shortcuts
   "shortcuts.getAll"(): Promise<Shortcut[]>;

--- a/src/shared/ui/events.ts
+++ b/src/shared/ui/events.ts
@@ -22,6 +22,7 @@ export interface UIEvents {
   "app.openLogDirectory": void;
   "app.openConfig": void;
   "app.openNoteAttachments": string;
+  "app.toggleAutoHideAppMenu": void;
 
   // Sidebar
   "sidebar.updateScroll": number;
@@ -96,6 +97,7 @@ export const LIST_OF_EVENTS: (keyof UIEvents)[] = [
   "app.openLogDirectory",
   "app.openConfig",
   "app.openNoteAttachments",
+  "app.toggleAutoHideAppMenu",
 
   // Sidebar
   "sidebar.updateScroll",

--- a/src/shared/ui/menu.ts
+++ b/src/shared/ui/menu.ts
@@ -5,7 +5,8 @@ export type Menu =
   | SubMenu
   | RoleMenu
   | EventMenu<UIEventType>
-  | RadioMenu<UIEventType>;
+  | RadioMenu<UIEventType>
+  | CheckboxMenu<UIEventType>;
 
 export interface Seperator extends BaseMenu {
   type: "separator";
@@ -39,6 +40,17 @@ export interface RadioMenu<Ev extends UIEventType = UIEventType>
   extends BaseMenu {
   label: string;
   type: "radio";
+  shortcut?: string;
+  checked?: boolean;
+  disabled?: boolean;
+  event: Ev;
+  eventInput?: UIEventInput<Ev>;
+}
+
+export interface CheckboxMenu<Ev extends UIEventType = UIEventType>
+  extends BaseMenu {
+  label: string;
+  type: "checkbox";
   shortcut?: string;
   checked?: boolean;
   disabled?: boolean;

--- a/test/main/json.spec.ts
+++ b/test/main/json.spec.ts
@@ -147,6 +147,34 @@ test("runSchemas applies changes", async () => {
     ),
   };
 
+  await expect(runSchemas(schemas, { version: 3 })).rejects.toThrow(
+    /Content had newer version \(3\) than latest schema \(2\)/,
+  );
+});
+
+test("runSchemas applies changes", async () => {
+  const schemas = {
+    1: z.object({
+      version: z.literal(1),
+      foo: z.string().default("bar"),
+    }),
+    2: z.preprocess(
+      (obj: any) => {
+        if (obj.version === 1) {
+          return {
+            ...obj,
+            version: 2,
+          };
+        }
+      },
+      z.object({
+        version: z.literal(2),
+        foo: z.string(),
+        bar: z.number().default(2),
+      }),
+    ),
+  };
+
   const migrated = await runSchemas(schemas, { version: 1 });
   const content = migrated.content as {
     version: number;


### PR DESCRIPTION
- Application menu can now be toggled to auto hide when not focused.
- Can be unhidden via `alt`.
![demo](https://user-images.githubusercontent.com/25796180/206597860-ac57ab82-dba8-4735-9650-5a1056964cc9.gif)
