### PR TITLE
Only quit app when safe

### DIFF
--- a/src/main/ipcs/app.ts
+++ b/src/main/ipcs/app.ts
@@ -6,18 +6,17 @@ import {
   shell,
 } from "electron";
 import { isRoleMenu, Menu as MenuType } from "../../shared/ui/menu";
-import { IpcChannel, IpcMainTS } from "../../shared/ipc";
+import { IpcChannel } from "../../shared/ipc";
 import { openInBrowser } from "../utils";
 import { UIEventType, UIEventInput } from "../../shared/ui/events";
 import { DEFAULT_SIDEBAR_WIDTH, SerializedAppState } from "../../shared/ui/app";
 
 import { JsonFile, loadJsonFile } from "../json";
-import { Config } from "../../shared/domain/config";
 import p from "path";
 import { MissingDataDirectoryError } from "../../shared/errors";
 import { NoteSort } from "../../shared/domain/note";
 import { APP_STATE_SCHEMAS } from "../schemas/appState";
-import { Logger } from "../../shared/logger";
+import { AppContext } from "..";
 
 export const APP_STATE_PATH = "ui.json";
 export const APP_STATE_DEFAULTS = {
@@ -36,13 +35,29 @@ export const APP_STATE_DEFAULTS = {
   focused: [],
 };
 
-export function appIpcs(
-  ipc: IpcMainTS,
-  config: JsonFile<Config>,
-  log: Logger,
-): void {
-  let appStateFile: JsonFile<SerializedAppState>;
+export function appIpcs(ctx: AppContext): void {
+  const { browserWindow, ipc, config } = ctx;
 
+  // We set a non-functional application menu at first so we can make things
+  // appear to load smoother visually. Once renderer has started we'll
+  // populate it with an actual menu.
+  browserWindow.setMenu(
+    Menu.buildFromTemplate([
+      { label: "File", enabled: false },
+      { label: "Edit", enabled: false },
+      { label: "View", enabled: false },
+    ]),
+  );
+
+  browserWindow.on("resize", async () => {
+    const [windowWidth, windowHeight] = browserWindow.getSize();
+    await config.update({
+      windowHeight,
+      windowWidth,
+    });
+  });
+
+  let appStateFile: JsonFile<SerializedAppState>;
   ipc.on("init", async () => {
     if (config.content.dataDirectory == null) {
       throw new MissingDataDirectoryError();

--- a/src/main/ipcs/app.ts
+++ b/src/main/ipcs/app.ts
@@ -36,7 +36,7 @@ export const APP_STATE_DEFAULTS = {
 };
 
 export function appIpcs(ctx: AppContext): void {
-  const { browserWindow, ipc, config } = ctx;
+  const { browserWindow, ipc, config, blockAppFromQuitting } = ctx;
 
   // We set a non-functional application menu at first so we can make things
   // appear to load smoother visually. Once renderer has started we'll
@@ -77,7 +77,9 @@ export function appIpcs(ctx: AppContext): void {
   });
 
   ipc.handle("app.saveAppState", async (_, appState) => {
-    await appStateFile.update(appState);
+    await blockAppFromQuitting(async () => {
+      await appStateFile.update(appState);
+    });
   });
 
   ipc.handle("app.showContextMenu", async (_, menus) => {

--- a/src/main/ipcs/config.ts
+++ b/src/main/ipcs/config.ts
@@ -1,13 +1,12 @@
 import { app, BrowserWindow, dialog, shell } from "electron";
-import { IpcMainTS } from "../../shared/ipc";
 import { Config } from "../../shared/domain/config";
 import { JsonFile, loadJsonFile } from "./../json";
-import { Logger } from "../../shared/logger";
 import { CONFIG_SCHEMAS } from "./../schemas/config";
 import { isDevelopment, isTest } from "../../shared/env";
 import * as path from "path";
 import * as fs from "fs";
 import * as fsp from "fs/promises";
+import { AppContext } from "..";
 
 export const CONFIG_FILE = "config.json";
 export const DEFAULT_DEV_DATA_DIRECTORY = "data";
@@ -15,11 +14,9 @@ export const DEFAULT_DEV_LOG_DIRECTORY = "logs";
 export const DEFAULT_WINDOW_HEIGHT = 600;
 export const DEFAULT_WINDOW_WIDTH = 800;
 
-export function configIpcs(
-  ipc: IpcMainTS,
-  config: JsonFile<Config>,
-  log: Logger,
-): void {
+export function configIpcs(ctx: AppContext): void {
+  const { ipc, config } = ctx;
+
   ipc.handle("config.get", () => config.content);
 
   ipc.handle("config.openInTextEditor", async () => {

--- a/src/main/ipcs/config.ts
+++ b/src/main/ipcs/config.ts
@@ -15,7 +15,7 @@ export const DEFAULT_WINDOW_HEIGHT = 600;
 export const DEFAULT_WINDOW_WIDTH = 800;
 
 export function configIpcs(ctx: AppContext): void {
-  const { ipc, config } = ctx;
+  const { ipc, config, blockAppFromQuitting } = ctx;
 
   ipc.handle("config.get", () => config.content);
 
@@ -50,7 +50,10 @@ export function configIpcs(ctx: AppContext): void {
       return;
     }
 
-    await config.update({ dataDirectory: filePaths[0] });
+    await blockAppFromQuitting(async () => {
+      await config.update({ dataDirectory: filePaths[0] });
+    });
+
     focusedWindow.reload();
   });
 }

--- a/src/main/ipcs/log.ts
+++ b/src/main/ipcs/log.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-console */
 import { differenceInCalendarDays, format, formatISO } from "date-fns";
 import { Config } from "../../shared/domain/config";
-import { IpcMainTS } from "../../shared/ipc";
 import { Logger } from "../../shared/logger";
 import { JsonFile } from "../json";
 import * as fsp from "fs/promises";
@@ -10,14 +9,13 @@ import * as p from "path";
 import { ISO_8601_REGEX } from "../../shared/utils";
 import chalk from "chalk";
 import * as os from "os";
+import { AppContext } from "..";
 
 const DELETE_LOGS_OLDER_THAN_DAYS = 14;
 
-export function logIpcs(
-  ipc: IpcMainTS,
-  configFile: JsonFile<Config>,
-  log: Logger,
-): void {
+export function logIpcs(ctx: AppContext): void {
+  const { ipc, log } = ctx;
+
   ipc.handle("log.info", async (_, message) =>
     log.info(`[RENDERER] ${message}`),
   );

--- a/src/main/ipcs/notes.ts
+++ b/src/main/ipcs/notes.ts
@@ -1,14 +1,12 @@
 import { createNote, Note, NoteSort } from "../../shared/domain/note";
 import { UUID_REGEX } from "../../shared/domain";
-import { Config } from "../../shared/domain/config";
 import { cloneDeep, difference, keyBy, omit, partition } from "lodash";
 import { shell } from "electron";
-import { IpcMainTS, NoteUpdateParams } from "../../shared/ipc";
+import { NoteUpdateParams } from "../../shared/ipc";
 import * as fs from "fs";
 import * as fsp from "fs/promises";
-import { JsonFile, loadJson, writeJson } from "./../json";
+import { loadJson, writeJson } from "./../json";
 import * as p from "path";
-import { Logger } from "../../shared/logger";
 import { NOTE_SCHEMAS } from "./../schemas/notes";
 import { z } from "zod";
 import { isDevelopment } from "../../shared/env";
@@ -17,6 +15,8 @@ import {
   registerAttachmentsProtocol,
 } from "../protocols/attachments";
 import { Attachment } from "../../shared/domain/protocols";
+import { openInBrowser } from "../utils";
+import { AppContext } from "..";
 
 export const ATTACHMENTS_DIRECTORY = "attachments";
 export const NOTES_DIRECTORY = "notes";
@@ -30,11 +30,9 @@ const noteUpdateSchema: z.Schema<NoteUpdateParams> = z.object({
   content: z.string().optional(),
 });
 
-export function noteIpcs(
-  ipc: IpcMainTS,
-  config: JsonFile<Config>,
-  log: Logger,
-): void {
+export function noteIpcs(ctx: AppContext): void {
+  const { browserWindow, ipc, config, log } = ctx;
+
   const { dataDirectory } = config.content;
   if (dataDirectory == null) {
     void log.debug(
@@ -45,6 +43,13 @@ export function noteIpcs(
   const noteDirectory = p.join(dataDirectory, NOTES_DIRECTORY);
 
   registerAttachmentsProtocol(noteDirectory);
+
+  // Override how all links are open so we can send them off to the user's
+  // web browser instead of opening them in the electron app.
+  browserWindow.webContents.setWindowOpenHandler(details => {
+    void openInBrowser(details.url);
+    return { action: "deny" };
+  });
 
   ipc.on("init", async () => {
     if (!fs.existsSync(noteDirectory)) {

--- a/src/main/ipcs/notes.ts
+++ b/src/main/ipcs/notes.ts
@@ -31,7 +31,7 @@ const noteUpdateSchema: z.Schema<NoteUpdateParams> = z.object({
 });
 
 export function noteIpcs(ctx: AppContext): void {
-  const { browserWindow, ipc, config, log } = ctx;
+  const { browserWindow, ipc, config, log, blockAppFromQuitting } = ctx;
 
   const { dataDirectory } = config.content;
   if (dataDirectory == null) {
@@ -67,7 +67,9 @@ export function noteIpcs(ctx: AppContext): void {
 
   ipc.handle("notes.create", async (_, params) => {
     const note = createNote(params);
-    await saveNoteToFS(noteDirectory, note);
+    await blockAppFromQuitting(async () => {
+      await saveNoteToFS(noteDirectory, note);
+    });
 
     return note;
   });
@@ -106,7 +108,9 @@ export function noteIpcs(ctx: AppContext): void {
     }
 
     note.dateUpdated = new Date();
-    await saveNoteToFS(noteDirectory, note);
+    await blockAppFromQuitting(async () => {
+      await saveNoteToFS(noteDirectory, note);
+    });
   });
 
   ipc.handle("notes.moveToTrash", async (_, id) => {

--- a/src/main/ipcs/shortcuts.ts
+++ b/src/main/ipcs/shortcuts.ts
@@ -1,13 +1,12 @@
-import { Config } from "../../shared/domain/config";
 import { DEFAULT_SHORTCUTS } from "../../shared/io/defaultShortcuts";
 import { parseKeyCodes } from "../../shared/io/keyCode";
-import { IpcMainTS } from "../../shared/ipc";
+import { BrowserWindowEvent, IpcChannel } from "../../shared/ipc";
 import { Section } from "../../shared/ui/app";
 import { UIEventInput, UIEventType } from "../../shared/ui/events";
-import { JsonFile, loadJsonFile } from "./../json";
+import { loadJsonFile } from "./../json";
 import p from "path";
 import { SHORTCUTS_SCHEMAS } from "./../schemas/shortcuts";
-import { Logger } from "../../shared/logger";
+import { AppContext } from "..";
 
 export interface Shortcuts {
   version: number;
@@ -34,11 +33,15 @@ export interface ShortcutOverride {
   disabled?: boolean;
 }
 
-export function shortcutIpcs(
-  ipc: IpcMainTS,
-  config: JsonFile<Config>,
-  log: Logger,
-): void {
+export function shortcutIpcs(ctx: AppContext): void {
+  const { browserWindow, ipc, config } = ctx;
+
+  browserWindow.on("blur", () => {
+    browserWindow.webContents.send(IpcChannel.BrowserWindow, {
+      event: BrowserWindowEvent.Blur,
+    });
+  });
+
   ipc.handle("shortcuts.getAll", async () => {
     const shortcuts = [...DEFAULT_SHORTCUTS];
 

--- a/src/renderer/preload.ts
+++ b/src/renderer/preload.ts
@@ -27,8 +27,8 @@ if (isDevelopment()) {
 }
 
 for (const channel of Object.values(IpcChannel)) {
-  ipcRenderer.on(channel, (_, val: unknown) => {
-    const ev = new CustomEvent(channel, { detail: val });
+  ipcRenderer.on(channel, (_, detail: unknown) => {
+    const ev = new CustomEvent(channel, { detail });
     window.dispatchEvent(ev);
   });
 }

--- a/test/__factories__/electron.ts
+++ b/test/__factories__/electron.ts
@@ -1,0 +1,21 @@
+import { BrowserWindow } from "electron";
+
+export function createBrowserWindow(
+  partial?: Partial<BrowserWindow>,
+): BrowserWindow {
+  // Gonna have to add mocks as we use them...
+  const bw: BrowserWindow = {} as any;
+  Object.assign(bw, partial);
+
+  bw.setMenu ??= jest.fn();
+  bw.on ??= jest.fn();
+  bw.setMenu = jest.fn();
+
+  if (bw.webContents == null) {
+    (bw as any).webContents = {
+      setWindowOpenHandler: jest.fn(),
+    } as any;
+  }
+
+  return bw;
+}

--- a/test/__factories__/ipc.ts
+++ b/test/__factories__/ipc.ts
@@ -75,7 +75,11 @@ export function createAppContext(
   const log = partial?.log ?? createLogger();
   const browserWindow = partial?.browserWindow ?? createBrowserWindow();
 
-  const ctx = { ipc, config, log, browserWindow };
+  const blockAppFromQuitting = jest.fn().mockImplementation(async cb => {
+    await cb();
+  });
+
+  const ctx = { ipc, config, log, browserWindow, blockAppFromQuitting };
 
   for (const ipc of ipcModules) {
     ipc(ctx);

--- a/test/__factories__/ipc.ts
+++ b/test/__factories__/ipc.ts
@@ -1,6 +1,11 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import { IpcMainInvokeEvent } from "electron";
+import { AppContext } from "../../src/main";
 import { IpcEvent, IpcMainTS, IpcSchema, IpcType } from "../../src/shared/ipc";
+import { createConfig } from "./config";
+import { createBrowserWindow } from "./electron";
+import { createJsonFile } from "./json";
+import { createLogger } from "./logger";
 
 export class MockedIpcMainTS implements IpcMainTS {
   // Type safety is not a concern here.
@@ -51,4 +56,30 @@ export class MockedIpcMainTS implements IpcMainTS {
 
 export function createIpcMainTS(): MockedIpcMainTS {
   return new MockedIpcMainTS();
+}
+
+export type MockedAppContext = { ipc: MockedIpcMainTS } & Omit<
+  AppContext,
+  "ipc"
+>;
+
+export const FAKE_DATA_DIRECTORY = "data";
+export function createAppContext(
+  partial?: Partial<MockedAppContext>,
+  ...ipcModules: Array<(ctx: AppContext) => void>
+): MockedAppContext {
+  const ipc = partial?.ipc ?? createIpcMainTS();
+  const config =
+    partial?.config ??
+    createJsonFile(createConfig({ dataDirectory: FAKE_DATA_DIRECTORY }));
+  const log = partial?.log ?? createLogger();
+  const browserWindow = partial?.browserWindow ?? createBrowserWindow();
+
+  const ctx = { ipc, config, log, browserWindow };
+
+  for (const ipc of ipcModules) {
+    ipc(ctx);
+  }
+
+  return ctx;
 }

--- a/test/main/index.spec.ts
+++ b/test/main/index.spec.ts
@@ -1,6 +1,6 @@
 import { setCspHeader } from "../../src/main";
 
-test("setCspheader", () => {
+test("setCspHeader", () => {
   const callback = jest.fn();
   setCspHeader({} as any, callback);
   expect(callback).toHaveBeenCalledWith({

--- a/test/main/index.spec.ts
+++ b/test/main/index.spec.ts
@@ -1,8 +1,11 @@
-import { getImgSrcCsp } from "../../src/main";
-import { Protocol } from "../../src/shared/domain/protocols";
+import { setCspHeader } from "../../src/main";
 
-test("getImgSrcCsp", () => {
-  const srcs = getImgSrcCsp().split(" ");
-  expect(srcs[0]).toBe("*");
-  expect(srcs[1]).toBe(`${Protocol.Attachment}://*`);
+test("setCspheader", () => {
+  const callback = jest.fn();
+  setCspHeader({} as any, callback);
+  expect(callback).toHaveBeenCalledWith({
+    responseHeaders: {
+      "Content-Security-Policy": [`img-src * attachment://*`],
+    },
+  });
 });


### PR DESCRIPTION
- Refactored ipc modules on `main` to be more self contained and easier to test
- Introduced a new helper `blockAppFromQuitting` that can be used to prevent the app from closing while we are writing to the file system.


`blockAppFromQuitting` was added because a couple of json files have been corrupted due to the app closing while in the middle of writing to them. The new helper lets the app keep running in the background until we've finished writing to the file.