### PR TITLE
Fix app crashing when deleting notes with children

### DIFF
--- a/src/renderer/utils/deleteNoteIfConfirmed.ts
+++ b/src/renderer/utils/deleteNoteIfConfirmed.ts
@@ -1,3 +1,4 @@
+import { keyBy } from "lodash";
 import { flatten, getNoteById } from "../../shared/domain/note";
 import { filterOutStaleNoteIds } from "../../shared/ui/app";
 import { StoreContext } from "../store";
@@ -14,7 +15,10 @@ export async function deleteNoteIfConfirmed(
   if (confirmed) {
     await window.ipc("notes.moveToTrash", note.id);
 
-    const otherNotes = flatten(notes).filter(n => n.id !== note.id);
+    // Flatten so we can remove children from state as well.
+    const deletedNotes = keyBy(flatten([note]), "id");
+
+    const otherNotes = flatten(notes).filter(n => deletedNotes[n.id] == null);
     ctx.setUI(ui => filterOutStaleNoteIds(ui, otherNotes, false));
 
     ctx.setNotes(notes => {

--- a/src/shared/ui/app.ts
+++ b/src/shared/ui/app.ts
@@ -42,7 +42,6 @@ export interface Editor {
 export interface EditorTab {
   note: Note;
   lastActive?: Date;
-  fromPreviousSession?: boolean;
 }
 
 // If a note was deleted but was referenced elsewhere in the ui state we need to

--- a/test/renderer/components/Sidebar.spec.tsx
+++ b/test/renderer/components/Sidebar.spec.tsx
@@ -608,10 +608,15 @@ test("sidebar.deleteNote", async () => {
   const noteAId = uuid();
   const noteBId = uuid();
   const noteCId = uuid();
+  const noteDId = uuid();
 
   const store = createStore({
     notes: [
-      createNote({ id: noteAId, name: "A" }),
+      createNote({
+        id: noteAId,
+        name: "A",
+        children: [createNote({ id: noteDId, name: "D" })],
+      }),
       createNote({ id: noteBId, name: "B" }),
       createNote({ id: noteCId, name: "C" }),
     ],
@@ -644,6 +649,10 @@ test("sidebar.deleteNote", async () => {
   const { notes } = store.current.state;
   expect(notes).toContainEqual(expect.objectContaining({ id: noteBId }));
   expect(notes).toContainEqual(expect.objectContaining({ id: noteCId }));
+
+  // Note D was a child of deleted note A
+  expect(notes).not.toContainEqual(expect.objectContaining({ id: noteAId }));
+  expect(notes).not.toContainEqual(expect.objectContaining({ id: noteDId }));
 });
 
 test("sidebar.deleteSelectedNote", async () => {


### PR DESCRIPTION
There's a small bug that leaves stale notes in the store if the note that was deleted has children.

This crashes the app pretty hard and makes it completely in-op.

Reproduced:
![crashed](https://user-images.githubusercontent.com/25796180/208329309-b9bbc7b8-278e-41fd-92e4-b683735e4371.gif)

Fixed:
![fixed](https://user-images.githubusercontent.com/25796180/208329315-6d9c435d-5304-4b6c-a9f1-ee17335cf430.gif)

