### PR TITLE
Improve sidebar search

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -23,6 +23,7 @@ import { Config } from "../shared/domain/config";
 import { log } from "./logger";
 import { arrayify } from "../shared/utils";
 import { NoteDirectoryModal } from "./components/NoteDirectoryModal";
+import { searchNotes } from "./components/SidebarSearch";
 
 async function main() {
   let config: Config;
@@ -157,9 +158,19 @@ export async function loadInitialState(config: Config): Promise<State> {
     }))
     .filter(t => t.note != null) as EditorTab[];
 
+  // TODO: Find a better option than this. I suspect we need to refactor our store
+  // a bit to support external state better.
+  const searchResults = searchNotes(notes, ui.sidebar.searchString ?? "").map(
+    n => n.id,
+  );
+
   const deserializedAppState = filterOutStaleNoteIds(
     {
       ...ui,
+      sidebar: {
+        ...ui.sidebar,
+        searchResults,
+      },
       editor: {
         ...ui.editor,
         tabs: tabs.map(t => ({ ...t, fromPreviousSession: true })),

--- a/src/renderer/components/Editor.tsx
+++ b/src/renderer/components/Editor.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useEffect, useRef } from "react";
 import styled from "styled-components";
 import { Section } from "../../shared/ui/app";
 import { Ipc } from "../../shared/ipc";
-import { m2, m3 } from "../css";
+import { m3 } from "../css";
 import { Listener, Store } from "../store";
 import { Markdown } from "./Markdown";
 import { ModelAndViewState, Monaco } from "./Monaco";

--- a/src/renderer/components/EditorToolbar.tsx
+++ b/src/renderer/components/EditorToolbar.tsx
@@ -342,7 +342,7 @@ const TabsScrollable = styled(Scrollable)`
 
 export const openTab: Listener<"editor.openTab"> = async (ev, ctx) => {
   // Keep in sync with sidebar.openSelectedNotes listener
-  const { sidebar, editor, notes } = ctx.getState();
+  const { editor, notes } = ctx.getState();
 
   if (ev.value?.note == null) {
     return;

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -310,7 +310,10 @@ export function renderMenus(
       // Use note.sort for children. If not set, use next parent. Climb parent
       // tree until we hit root then default to using global sort.
       let sortToUse = note.sort;
-      const parents = getParents(note, notes);
+
+      // N.B. Pass store.state.notes because it includes every note over notes
+      // otherwise app will crash when searching notes due to parents missing.
+      const parents = getParents(note, store.state.notes);
       for (const p of parents) {
         sortToUse = p.sort;
         if (sortToUse != null) {

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -127,7 +127,6 @@ export function Sidebar(props: SidebarProps): JSX.Element {
     store.on(["sidebar.renameNote", "sidebar.renameSelectedNote"], renameNote);
     store.on(["sidebar.deleteNote", "sidebar.deleteSelectedNote"], deleteNote);
     store.on("sidebar.dragNote", dragNote);
-    store.on("sidebar.search", search);
     store.on("sidebar.collapseAll", collapseAll);
     store.on("sidebar.expandAll", expandAll);
     store.on("sidebar.setNoteSort", setNoteSort);
@@ -161,7 +160,6 @@ export function Sidebar(props: SidebarProps): JSX.Element {
         deleteNote,
       );
       store.off("sidebar.dragNote", dragNote);
-      store.off("sidebar.search", search);
       store.off("sidebar.collapseAll", collapseAll);
       store.off("sidebar.expandAll", expandAll);
       store.off("sidebar.setNoteSort", setNoteSort);
@@ -672,17 +670,6 @@ export const dragNote: Listener<"sidebar.dragNote"> = async (
   if (newParent != null && !sidebar.expanded?.some(id => id === newParentId)) {
     toggleExpanded(ctx, newParent.id);
   }
-};
-
-export const search: Listener<"sidebar.search"> = async (
-  { value: searchString },
-  ctx,
-) => {
-  ctx.setUI({
-    sidebar: {
-      searchString,
-    },
-  });
 };
 
 export const expandAll: Listener<"sidebar.expandAll"> = async (_, ctx) => {

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -23,7 +23,7 @@ import {
   faChevronDown,
   faChevronRight,
 } from "@fortawesome/free-solid-svg-icons";
-import { searchNotes, SidebarSearch } from "./SidebarSearch";
+import { SidebarSearch } from "./SidebarSearch";
 import { EditorTab } from "../../shared/ui/app";
 import { SidebarNewNoteButton } from "./SidebarNewNoteButton";
 import { Section } from "../../shared/ui/app";
@@ -40,14 +40,9 @@ export function Sidebar(props: SidebarProps): JSX.Element {
   const { store } = props;
   const { state } = store;
   const { input } = state.sidebar;
+  const { notes } = state;
   const expandedLookup = keyBy(state.sidebar.expanded, e => e);
   const selectedLookup = keyBy(state.sidebar.selected, s => s);
-
-  const { searchString } = state.sidebar;
-  const notes = useMemo(
-    () => searchNotes(state.notes, searchString),
-    [searchString, state.notes],
-  );
 
   const [menus, noteIds] = useMemo(
     () => renderMenus(notes, store, input, expandedLookup, selectedLookup),
@@ -173,8 +168,6 @@ export function Sidebar(props: SidebarProps): JSX.Element {
       store.off("sidebar.openSelectedNotes", openSelectedNotes);
     };
   }, [noteIds, state.sidebar, store]);
-
-  // TODO: Where did calc(100% - 100px) come from?
 
   return (
     <SidebarResizable

--- a/src/renderer/components/SidebarSearch.tsx
+++ b/src/renderer/components/SidebarSearch.tsx
@@ -184,6 +184,9 @@ const SearchOverlay = styled.div`
   width: 100%;
   background-color: ${THEME.sidebar.search.background};
   z-index: ${ZIndex.SearchOverlay};
+
+  border-bottom-left-radius: 0.4rem;
+  border-bottom-right-radius: 0.4rem;
 `;
 
 const SearchResult = styled.div<{ selected: boolean }>`

--- a/src/renderer/components/SidebarSearch.tsx
+++ b/src/renderer/components/SidebarSearch.tsx
@@ -76,6 +76,7 @@ export function SidebarSearch(props: SidebarSearchProps): JSX.Element {
         ref={inputRef}
         value={searchString}
         onInput={onInput}
+        roundBottomCorners={!searchHasFocus || matches.length === 0}
       ></SearchInput>
       <SearchIcon icon={faSearch} />
       {!isEmpty(searchString) && (
@@ -113,7 +114,7 @@ const DeleteIcon = styled(Icon)`
   }
 `;
 
-const SearchInput = styled.input`
+const SearchInput = styled.input<{ roundBottomCorners: boolean }>`
   height: 3.2rem !important; // Keep in sync with height of new note button
   ${w100};
   padding: 0 3.2rem;
@@ -121,10 +122,14 @@ const SearchInput = styled.input`
   border: none;
   outline: none;
   -webkit-appearance: none;
-  border-radius: 4px;
   background-color: ${THEME.sidebar.search.background};
   color: ${THEME.sidebar.search.font};
   font-size: 1.4rem;
+
+  border-top-left-radius: 0.4rem;
+  border-top-right-radius: 0.4rem;
+  border-bottom-left-radius: ${p => (p.roundBottomCorners ? "0.4rem" : "0")};
+  border-bottom-right-radius: ${p => (p.roundBottomCorners ? "0.4rem" : "0")};
 `;
 
 const SearchOverlay = styled.div`

--- a/src/renderer/css.ts
+++ b/src/renderer/css.ts
@@ -20,7 +20,8 @@ export const THEME = {
       deleteIconHover: OpenColor.red[7],
       background: OpenColor.white,
       font: OpenColor.gray[8],
-      resultBackgroundHover: OpenColor.gray[3],
+      selectedResult: OpenColor.gray[3],
+      resultBackgroundHover: OpenColor.gray[1],
     },
     input: {
       font: OpenColor.gray[2],

--- a/src/renderer/css.ts
+++ b/src/renderer/css.ts
@@ -15,11 +15,12 @@ export const THEME = {
       font: OpenColor.red[9],
     },
     search: {
-      icon: OpenColor.white,
-      deleteIcon: OpenColor.red[0],
+      icon: OpenColor.gray[6],
+      deleteIcon: OpenColor.gray[6],
       deleteIconHover: OpenColor.red[7],
-      background: OpenColor.gray[8],
-      font: OpenColor.gray[2],
+      background: OpenColor.white,
+      font: OpenColor.gray[8],
+      resultBackgroundHover: OpenColor.gray[3],
     },
     input: {
       font: OpenColor.gray[2],
@@ -43,6 +44,10 @@ export const THEME = {
     },
   },
 };
+
+export enum ZIndex {
+  SearchOverlay = 10,
+}
 
 export const rounded = css`
   border-radius: 0.2rem;

--- a/src/renderer/io/shortcuts.ts
+++ b/src/renderer/io/shortcuts.ts
@@ -15,8 +15,8 @@ import { Section } from "../../shared/ui/app";
 import { log } from "../logger";
 import { BrowserWindowEvent, IpcChannel } from "../../shared/ipc";
 
-const INITIAL_DELAY_MS = 250;
-const REPEAT_DELAY_MS = 125;
+const INITIAL_DELAY_MS = 400;
+const REPEAT_DELAY_MS = 200;
 
 export function useShortcuts(store: Store): void {
   const { dispatch, state } = store;

--- a/src/shared/io/defaultShortcuts.ts
+++ b/src/shared/io/defaultShortcuts.ts
@@ -54,6 +54,21 @@ const shortcuts: Shortcut[] = [
     keys: [KeyCode.Control, KeyCode.Shift, KeyCode.LetterF],
   },
   {
+    name: "sidebar.moveSelectedSearchResultUp",
+    event: "sidebar.moveSelectedSearchResultUp",
+    keys: [KeyCode.ArrowUp],
+    when: Section.SidebarSearch,
+    repeat: true,
+  },
+  {
+    name: "sidebar.moveSelectedSearchResultDown",
+    event: "sidebar.moveSelectedSearchResultDown",
+    keys: [KeyCode.ArrowDown],
+    when: Section.SidebarSearch,
+    repeat: true,
+  },
+
+  {
     name: "sidebar.scrollDown",
     event: "sidebar.scrollDown",
     keys: COMMON_KEY_COMBOS.scrollDown,

--- a/src/shared/ui/app.ts
+++ b/src/shared/ui/app.ts
@@ -22,6 +22,8 @@ export enum Section {
 
 export interface Sidebar {
   searchString?: string;
+  searchResults?: string[];
+  searchSelected?: string;
   hidden?: boolean;
   width: string;
   scroll: number;

--- a/src/shared/ui/events.ts
+++ b/src/shared/ui/events.ts
@@ -48,6 +48,7 @@ export interface UIEvents {
   "sidebar.moveSelectionDown": void;
   "sidebar.search": string;
   "sidebar.focusSearch": void;
+  "sidebar.selectSearchResult": string;
   "sidebar.openSelectedNotes": void;
 
   // Editor
@@ -122,6 +123,7 @@ export const LIST_OF_EVENTS: (keyof UIEvents)[] = [
   "sidebar.moveSelectionDown",
   "sidebar.search",
   "sidebar.focusSearch",
+  "sidebar.selectSearchResult",
   "sidebar.openSelectedNotes",
 
   // Editor

--- a/src/shared/ui/events.ts
+++ b/src/shared/ui/events.ts
@@ -49,6 +49,8 @@ export interface UIEvents {
   "sidebar.search": string;
   "sidebar.focusSearch": void;
   "sidebar.selectSearchResult": string;
+  "sidebar.moveSelectedSearchResultUp": void;
+  "sidebar.moveSelectedSearchResultDown": void;
   "sidebar.openSelectedNotes": void;
 
   // Editor
@@ -124,6 +126,8 @@ export const LIST_OF_EVENTS: (keyof UIEvents)[] = [
   "sidebar.search",
   "sidebar.focusSearch",
   "sidebar.selectSearchResult",
+  "sidebar.moveSelectedSearchResultUp",
+  "sidebar.moveSelectedSearchResultDown",
   "sidebar.openSelectedNotes",
 
   // Editor

--- a/test/renderer/components/SidebarSearch.spec.tsx
+++ b/test/renderer/components/SidebarSearch.spec.tsx
@@ -37,7 +37,7 @@ test("searchNotes nested", () => {
   const notes = [
     createNote({
       id: parentId,
-      name: "parent",
+      name: "parentq",
       content: "Random string lol",
       children: [
         createNote({

--- a/test/renderer/components/SidebarSearch.spec.tsx
+++ b/test/renderer/components/SidebarSearch.spec.tsx
@@ -32,6 +32,7 @@ test("searchNotes roots", () => {
 test("searchNotes nested", () => {
   const parentId = uuid();
   const nestedId = uuid();
+  const doubleNestedId = uuid();
 
   const notes = [
     createNote({
@@ -47,6 +48,12 @@ test("searchNotes nested", () => {
         createNote({
           name: "blarg",
           content: "",
+          children: [
+            createNote({
+              id: doubleNestedId,
+              name: "qqq",
+            }),
+          ],
         }),
       ],
     }),
@@ -79,5 +86,12 @@ test("searchNotes nested", () => {
   expect(matches3).toHaveLength(1);
   expect(matches3[0]).toMatchObject({
     id: nestedId,
+  });
+
+  //Match just the double nested note
+  const matches4 = searchNotes(notes, "qqq");
+  expect(matches4).toHaveLength(1);
+  expect(matches4[0]).toMatchObject({
+    id: doubleNestedId,
   });
 });


### PR DESCRIPTION
To make searching more intuitive for users, results are now shown in an overlay below the search input instead of filtering results in the sidebar.

![Peek 2022-12-25 08-35](https://user-images.githubusercontent.com/25796180/209470152-0400933f-2fdc-4740-b17f-48e30b516a9c.gif)


This helps sidestep some awkward edge cases about how to show search results while retaining the tree like structure of notes.