### PR TITLE
Fix note names overflowing

### DIFF
--- a/src/renderer/components/EditorTab.tsx
+++ b/src/renderer/components/EditorTab.tsx
@@ -64,6 +64,7 @@ const FlexRow = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
+  min-width: 0;
 `;
 
 const StyledTab = styled.a<{ active?: boolean }>`
@@ -97,6 +98,7 @@ const StyledText = styled.span`
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
+  min-width: 0;
 `;
 
 const StyledDelete = styled(Icon)`

--- a/src/renderer/components/SidebarMenu.tsx
+++ b/src/renderer/components/SidebarMenu.tsx
@@ -115,6 +115,11 @@ const StyledMenuIcon = styled(Icon)`
 const StyledMenuText = styled.div`
   color: ${THEME.sidebar.font};
   font-size: ${SIDEBAR_MENU_FONT_SIZE};
+
+  overflow: hidden;
+  min-width: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 export interface SidebarInputProps {

--- a/src/renderer/components/shared/Resizable.tsx
+++ b/src/renderer/components/shared/Resizable.tsx
@@ -3,6 +3,7 @@ import { stripUnit } from "polished";
 import React, { PropsWithChildren, useRef, useState } from "react";
 import styled from "styled-components";
 import { PX_REGEX } from "../../../shared/domain";
+import { ZIndex } from "../../css";
 import { useMouseDrag } from "../../io/mouse";
 
 export interface ResizableProps {
@@ -79,4 +80,5 @@ export function Resizable(
 
 const Handle = styled.div`
   cursor: ew-resize;
+  z-index: ${ZIndex.ResizeHandle};
 `;

--- a/src/renderer/css.ts
+++ b/src/renderer/css.ts
@@ -48,6 +48,7 @@ export const THEME = {
 
 export enum ZIndex {
   SearchOverlay = 10,
+  ResizeHandle = 100,
 }
 
 export const rounded = css`


### PR DESCRIPTION
Notes with really long names were overflowing their containers in the sidebar and editor toolbar
![before](https://user-images.githubusercontent.com/25796180/209484962-e9997ee6-630b-474f-8a9b-6a729f9445d5.png)

Fixed:
![after](https://user-images.githubusercontent.com/25796180/209484965-b60b6e88-7d4d-45e3-9034-2b549887c5d0.png)
