### PR TITLE
Truncate notes in search

### DIFF
--- a/src/renderer/components/SidebarSearch.tsx
+++ b/src/renderer/components/SidebarSearch.tsx
@@ -74,7 +74,7 @@ export function SidebarSearch(props: SidebarSearchProps): JSX.Element {
           })
         }
       >
-        {n.name}
+        <TruncatedText>{n.name}</TruncatedText>
       </SearchResult>
     );
   });
@@ -195,6 +195,7 @@ const SearchResult = styled.div<{ selected: boolean }>`
   align-items: center;
   font-size: 1.4rem;
   ${px3}
+  min-width: 0;
 
   background-color: ${p =>
     p.selected ? THEME.sidebar.search.selectedResult : ""} !important;
@@ -202,6 +203,12 @@ const SearchResult = styled.div<{ selected: boolean }>`
   &:hover {
     background-color: ${THEME.sidebar.search.resultBackgroundHover};
   }
+`;
+
+const TruncatedText = styled.div`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 export function searchNotes(notes: Note[], searchString?: string): Note[] {


### PR DESCRIPTION
This is a small bug that was missed in #25. Note names in the search results will overflow if the name is too long:

![before](https://user-images.githubusercontent.com/25796180/209499709-fd6053db-4274-4686-972d-d22d5a0e460d.png)

Fixed:
![fixed](https://user-images.githubusercontent.com/25796180/209499718-8a1901be-efa4-4aae-9d0a-e90e76e2d07f.png)
