### PR TITLE
Show blurb explaining how to undo a delete

### DIFF
--- a/src/renderer/utils/deleteNoteIfConfirmed.ts
+++ b/src/renderer/utils/deleteNoteIfConfirmed.ts
@@ -11,7 +11,11 @@ export async function deleteNoteIfConfirmed(
   const { notes } = ctx.getState();
 
   const note = getNoteById(notes, noteId);
-  const confirmed = await promptConfirmAction("delete", `note ${note.name}`);
+  const confirmed = await promptConfirmAction(
+    "delete",
+    `"${note.name}"`,
+    "The note can be restored from your computer's trash",
+  );
   if (confirmed) {
     await window.ipc("notes.moveToTrash", note.id);
 

--- a/src/renderer/utils/prompt.ts
+++ b/src/renderer/utils/prompt.ts
@@ -39,6 +39,7 @@ export const promptFatal = async (
 export const promptConfirmAction = async (
   verb: string,
   name: string,
+  detail?: string,
 ): Promise<boolean> => {
   const opts: PromptOptions<boolean> = {
     text: `Are you sure you want to ${verb} ${name}?`,
@@ -48,6 +49,7 @@ export const promptConfirmAction = async (
     ],
     type: "info",
     title: `Confirm ${verb}`,
+    detail,
   };
 
   const pickedButton = await ipc("app.promptUser", opts);


### PR DESCRIPTION
Deleting notes is risky, and we need to make it easy to tell the action can be undone. Whenever a note is deleted the file is always moved to the operating systems trash directory, but this was never made clear to the user.

A new blurb has been added to the confirmation modal to make this more clear.
![new-blurb](https://user-images.githubusercontent.com/25796180/209500161-e53695e3-0eb8-41f7-a33e-dbb7215ac078.png)
