### PR TITLE
Attachments with spaces break

### DIFF
--- a/src/main/ipc/plugins/notes.ts
+++ b/src/main/ipc/plugins/notes.ts
@@ -221,10 +221,6 @@ export const noteIpcPlugin: IpcPlugin = {
           attachment.path,
           p.join(noteAttachmentsDirectory, attachment.name),
         );
-
-        console.log("COPIED TO ATTACHMENTS");
-      } else {
-        console.log("WAS ALREADY IN ATTACHMENTS");
       }
 
       attachments.push({

--- a/src/main/ipc/plugins/notes.ts
+++ b/src/main/ipc/plugins/notes.ts
@@ -197,7 +197,7 @@ export const noteIpcPlugin: IpcPlugin = {
       // directory. This prevents us from duplicating the file if the user were
       // to drag and drop a file that is already a known attachment.
       if (
-        p.relative(noteAttachmentsDirectory, attachment.path).startsWith("..")
+        p.relative(noteAttachmentsDirectory, attachment.name).startsWith("..")
       ) {
         // Ensure filename is always unique by appending a number to the end of it
         // if we detect the file already exists.

--- a/src/main/ipc/plugins/notes.ts
+++ b/src/main/ipc/plugins/notes.ts
@@ -14,7 +14,7 @@ import {
   parseAttachmentPath,
 } from "../../protocols/attachments";
 import { NOTE_SCHEMAS } from "../../schemas/notes";
-import { openInBrowser } from "../../utils";
+import { isChildOf, openInBrowser } from "../../utils";
 import * as fs from "fs";
 import * as p from "path";
 
@@ -196,9 +196,7 @@ export const noteIpcPlugin: IpcPlugin = {
       // Only copy over the attachment if it was outside of the note's attachment
       // directory. This prevents us from duplicating the file if the user were
       // to drag and drop a file that is already a known attachment.
-      if (
-        p.relative(noteAttachmentsDirectory, attachment.name).startsWith("..")
-      ) {
+      if (!isChildOf(noteAttachmentsDirectory, attachment.path)) {
         // Ensure filename is always unique by appending a number to the end of it
         // if we detect the file already exists.
         const parsedFile = p.parse(attachment.name);
@@ -223,6 +221,10 @@ export const noteIpcPlugin: IpcPlugin = {
           attachment.path,
           p.join(noteAttachmentsDirectory, attachment.name),
         );
+
+        console.log("COPIED TO ATTACHMENTS");
+      } else {
+        console.log("WAS ALREADY IN ATTACHMENTS");
       }
 
       attachments.push({

--- a/src/main/protocols/attachments.ts
+++ b/src/main/protocols/attachments.ts
@@ -4,6 +4,7 @@ import path from "path";
 import fs from "fs";
 import { UUID_REGEX } from "../../shared/domain";
 import { ATTACHMENTS_DIRECTORY } from "../ipc/plugins/notes";
+import { isChildOf } from "../utils";
 
 export function registerAttachmentsProtocol(noteDirectoryPath: string): void {
   protocol.registerFileProtocol(Protocol.Attachment, (req, cb) => {
@@ -55,7 +56,7 @@ export function parseAttachmentPath(
 
   const attachmentFile = path.join(attachmentsPath, filePath);
 
-  if (path.relative(attachmentsPath, attachmentFile).startsWith("..")) {
+  if (!isChildOf(attachmentsPath, attachmentFile)) {
     throw new Error(
       `${attachmentFile} is outside of attachment directory for ${noteId}, and cannot be loaded.`,
     );

--- a/src/main/utils.ts
+++ b/src/main/utils.ts
@@ -4,6 +4,7 @@ import {
   shell,
 } from "electron";
 import { Protocol } from "../shared/domain/protocols";
+import * as path from "path";
 
 export function openInBrowser(url: string): Promise<void> {
   if (!url.startsWith("http")) {
@@ -26,4 +27,9 @@ export function setCspHeader(
       details.responseHeaders,
     ),
   });
+}
+
+export function isChildOf(parent: string, dir: string): boolean {
+  const relative = path.relative(parent, dir);
+  return !relative.startsWith("..") && !path.isAbsolute(relative);
 }

--- a/src/shared/domain/protocols.ts
+++ b/src/shared/domain/protocols.ts
@@ -8,7 +8,13 @@ export enum Protocol {
 
 export interface FileInfo {
   mimeType: string;
+  /**
+   * Full path of the attachment including file name and extension.
+   */
   path: string;
+  /**
+   * File name including extension. Ex: "foo.txt"
+   */
   name: string;
 }
 

--- a/test/main/ipc/plugins/notes.spec.ts
+++ b/test/main/ipc/plugins/notes.spec.ts
@@ -434,7 +434,12 @@ test("notes.importAttachments", async () => {
           ATTACHMENTS_DIRECTORY,
           "existing-attachment.txt",
         ),
-        name: "existing-attachment.txt",
+        name: path.join(
+          FAKE_NOTE_DIRECTORY,
+          noteId,
+          ATTACHMENTS_DIRECTORY,
+          "existing-attachment.txt",
+        ),
         mimeType: "text/plain",
       },
     ],
@@ -442,7 +447,9 @@ test("notes.importAttachments", async () => {
 
   // We can tell if the file was copied over based off it's name because it would
   // end in (1).
-  expect(existingAttachment[0].name).toBe("existing-attachment.txt");
+  expect(existingAttachment[0].name).toBe(
+    `${FAKE_NOTE_DIRECTORY}/${noteId}/${ATTACHMENTS_DIRECTORY}/existing-attachment.txt`,
+  );
 });
 
 test("loadNotes empty", async () => {

--- a/test/main/ipc/plugins/notes.spec.ts
+++ b/test/main/ipc/plugins/notes.spec.ts
@@ -434,12 +434,7 @@ test("notes.importAttachments", async () => {
           ATTACHMENTS_DIRECTORY,
           "existing-attachment.txt",
         ),
-        name: path.join(
-          FAKE_NOTE_DIRECTORY,
-          noteId,
-          ATTACHMENTS_DIRECTORY,
-          "existing-attachment.txt",
-        ),
+        name: "existing-attachment.txt",
         mimeType: "text/plain",
       },
     ],
@@ -447,9 +442,7 @@ test("notes.importAttachments", async () => {
 
   // We can tell if the file was copied over based off it's name because it would
   // end in (1).
-  expect(existingAttachment[0].name).toBe(
-    `${FAKE_NOTE_DIRECTORY}/${noteId}/${ATTACHMENTS_DIRECTORY}/existing-attachment.txt`,
-  );
+  expect(existingAttachment[0].name).toBe(`existing-attachment.txt`);
 });
 
 test("loadNotes empty", async () => {

--- a/test/main/utils.spec.ts
+++ b/test/main/utils.spec.ts
@@ -1,5 +1,5 @@
 import { shell } from "electron";
-import { openInBrowser } from "../../src/main/utils";
+import { isChildOf, openInBrowser } from "../../src/main/utils";
 import { setCspHeader } from "../../src/main/utils";
 
 test("openInBrowser", async () => {
@@ -19,4 +19,13 @@ test("setCspHeader", () => {
       "Content-Security-Policy": [`img-src * attachment://*`],
     },
   });
+});
+
+test.each([
+  ["foo", "bar", false],
+  ["foo", "foo/../../bar", false],
+  ["foo", "foo/bar", true],
+  ["foo", "foo/bar/baz.txt", true],
+])("isChildOf", (parent, child, isChild) => {
+  expect(isChildOf(parent, child)).toBe(isChild);
 });


### PR DESCRIPTION
Fixed a small bug that was preventing files from being copied over when dragged and dropped if they contained spaces.

This also fixes another bug that prevents the app from duplicating attachments if they were dragged and dropped and had already been in the note's attachment directory.