### PR TITLE
Fix creating notes from context menu

### DIFF
--- a/src/shared/domain/note.ts
+++ b/src/shared/domain/note.ts
@@ -98,6 +98,11 @@ export function createNote(props: Partial<Note> & Pick<Note, "name">): Note {
   note.dateCreated ??= new Date();
   note.content ??= "";
 
+  // Trim out null parent id
+  if (note.parent === null) {
+    delete note.parent;
+  }
+
   if (!isEmpty(note.children)) {
     for (const child of note.children!) {
       child.parent = note.id;

--- a/test/main/ipc/plugins/notes.spec.ts
+++ b/test/main/ipc/plugins/notes.spec.ts
@@ -55,6 +55,12 @@ function createMetadata(props?: Partial<NoteMetadata>): NoteMetadata {
   return metadata;
 }
 
+test("createNote", () => {
+  // Trims out null
+  const note = createNote({ name: "foo", parent: null });
+  expect(note).not.toHaveProperty("parent");
+});
+
 test("registers attachment protocol", async () => {
   mockFS({
     [FAKE_NOTE_DIRECTORY]: {},


### PR DESCRIPTION
Fixes a bug where the app crashes when creating notes from the sidebar context menu because of a validation error (parent was null when only undefined is allowed)